### PR TITLE
Adapter trait

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -1,0 +1,23 @@
+use server::{Id, Entry, Result};
+
+pub trait Transaction<D> {
+    fn commit(self) -> Result<()>;
+
+    // TODO: these are the guts of LmdbAdapter leaking out. They should get moved elsewhere
+    fn get(&self, database: D, key: &[u8]) -> Result<&[u8]>;
+    fn find<P>(&self, db: D, key: &[u8], predicate: P) -> Result<&[u8]> where P: Fn(&[u8]) -> bool;
+}
+
+pub trait Adapter<'a, D, R: Transaction<D>, W: Transaction<D>> {
+    fn ro_transaction(&'a self) -> Result<R>;
+    fn rw_transaction(&'a self) -> Result<W>;
+    fn next_available_id(&self, txn: &W) -> Result<Id>;
+    fn create_entry<'b>(&'b self,
+                        txn: &'b mut W,
+                        id: Id,
+                        parent_id: Id,
+                        name: &'b str,
+                        objectclass: &'b str)
+                        -> Result<Entry>;
+    fn find_entry<'b, T: Transaction<D>>(&'b self, txn: &'b T, path: &str) -> Result<Entry>;
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,15 +6,16 @@ use clap::{App, Arg, SubCommand};
 extern crate ring;
 extern crate time;
 
+mod adapter;
+mod lmdb_adapter;
 mod log;
-mod lmdb;
 mod objectclass;
 mod objecthash;
 mod password;
 mod server;
 mod signature;
 
-use lmdb::Adapter;
+use lmdb_adapter::LmdbAdapter;
 
 fn main() {
     let version = "v0.1";
@@ -35,6 +36,6 @@ fn main() {
         let path = matches.value_of("path").unwrap();
 
         println!("Creating database at: {}", path);
-        Adapter::create_database(Path::new(path)).unwrap();
+        LmdbAdapter::create_database(Path::new(path)).unwrap();
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use ring::rand;
 
-use lmdb::Adapter;
+use lmdb_adapter::LmdbAdapter;
 use log::{Log, DigestAlgorithm};
 use password;
 use password::PasswordAlgorithm;
@@ -29,7 +29,7 @@ pub enum Error {
 pub type Result<T> = result::Result<T, Error>;
 
 pub struct Server {
-    adapter: Adapter,
+    adapter: LmdbAdapter,
 }
 
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
@@ -46,10 +46,6 @@ pub struct Node<'a> {
 pub struct Entry<'a> {
     pub node: Node<'a>,
     pub objectclass: &'a str,
-}
-
-pub trait TxCommit {
-    fn commit(self) -> Result<()>;
 }
 
 impl Server {
@@ -77,7 +73,7 @@ impl Server {
                                 &admin_keypair_sealed,
                                 DigestAlgorithm::SHA256);
 
-        Adapter::create_database(path);
+        LmdbAdapter::create_database(path).unwrap();
         Ok(())
     }
 }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,4 +1,4 @@
-use ring::{rand, signature, aead};
+use ring::{signature, aead};
 use ring::rand::SecureRandom;
 
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]


### PR DESCRIPTION
Factors the public interface of an Adapter into a trait that could potentially be implemented by other LMDB-like storage backends.

This could be useful for e.g. switching to a pure Rust LMDB-alike storage engine.
