### PR TITLE
Initial support for committing the genesis block

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -1,5 +1,5 @@
 use objectclass::ObjectClass;
-use server::{Id, Entry, Path, Result};
+use server::{Id, Node, Entry, Path, Result};
 
 pub trait Transaction<D> {
     fn commit(self) -> Result<()>;
@@ -18,5 +18,6 @@ pub trait Adapter<'a, D, R: Transaction<D>, W: Transaction<D>> {
                      name: &'b str,
                      objectclass: ObjectClass)
                      -> Result<Entry>;
+    fn find_node<'b, T: Transaction<D>>(&'b self, txn: &'b T, path: &Path) -> Result<Node>;
     fn find_entry<'b, T: Transaction<D>>(&'b self, txn: &'b T, path: &Path) -> Result<Entry>;
 }

--- a/src/log.rs
+++ b/src/log.rs
@@ -19,10 +19,10 @@ pub enum OpType {
 }
 
 pub struct Op {
-    optype: OpType,
-    path: Path,
-    objectclass: ObjectClass,
-    data: Vec<u8>,
+    pub optype: OpType,
+    pub path: Path,
+    pub objectclass: ObjectClass,
+    pub data: Vec<u8>,
 }
 
 pub struct OobData {
@@ -31,14 +31,14 @@ pub struct OobData {
 }
 
 pub struct Block {
-    id: Option<[u8; 32]>,
-    parent: [u8; 32],
-    timestamp: u64,
-    ops: Vec<Op>,
-    oob_data: Vec<OobData>,
-    comment: String,
-    signed_by: Option<[u8; 32]>,
-    signature: Option<[u8; 64]>,
+    pub id: Option<[u8; 32]>,
+    pub parent: [u8; 32],
+    pub timestamp: u64,
+    pub ops: Vec<Op>,
+    pub oob_data: Vec<OobData>,
+    pub comment: String,
+    pub signed_by: Option<[u8; 32]>,
+    pub signature: Option<[u8; 64]>,
 }
 
 impl Op {
@@ -121,7 +121,9 @@ impl Block {
                          -> Block {
         let mut block = Block::new(GENESIS_BLOCK_ID);
 
+        // TODO: use a real type for the root entry
         block.op(OpType::Add, Path::new("/").unwrap(), ObjectClass::Root, logid);
+        block.op(OpType::Add, Path::new("/system").unwrap(), ObjectClass::OU, b"");
 
         let public_key_bytes = admin_keypair.public_key_bytes();
 


### PR DESCRIPTION
This adds initial support for processing the genesis block created by `Block::genesis_block` and committing the operations it includes to LMDB.

Still needed: storing the block itself in LMDB for replication. Also some refactoring is probably in order.
