### PR TITLE
Refactor Error type

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -1,5 +1,6 @@
 use objectclass::ObjectClass;
-use server::{Id, Node, Entry, Path, Result};
+use error::Result;
+use server::{Id, Node, Entry, Path};
 
 pub trait Transaction<D> {
     fn commit(self) -> Result<()>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,42 @@
+use std::fmt;
+use std::result::Result as StdResult;
+use std::error::Error as StdError;
+
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+pub enum Error {
+    Rng,
+    DbCreate,
+    DbOpen,
+    DbWrite,
+    DbCorrupt,
+    Parse,
+    Transaction,
+    PathInvalid,
+    NotFound,
+    EntryAlreadyExists,
+}
+
+impl StdError for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::Rng => "the system random number generator returned an error",
+            Error::DbCreate => "unable to create database",
+            Error::DbOpen => "unable to open database",
+            Error::DbWrite => "unable to write to database",
+            Error::DbCorrupt => "the contents of the database are invalid",
+            Error::Parse => "unable to parse data",
+            Error::Transaction => "the current transaction cannot be completed because of an error",
+            Error::PathInvalid => "the given path is syntactically invalid",
+            Error::NotFound => "the requested object was not found",
+            Error::EntryAlreadyExists => "an attempt was made to insert a duplicate entry",
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{}", self.description())
+    }
+}
+
+pub type Result<T> = StdResult<T, Error>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ extern crate serde_json;
 extern crate time;
 
 mod adapter;
+mod error;
 mod lmdb_adapter;
 mod log;
 mod objectclass;

--- a/src/objectclass.rs
+++ b/src/objectclass.rs
@@ -1,8 +1,8 @@
 use std::string::ToString;
 use ring::digest::Digest;
 
+use error::{Error, Result};
 use objecthash::ObjectHash;
-use server::{Result, Error};
 
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub enum ObjectClass {
@@ -21,7 +21,7 @@ impl ObjectClass {
             b"ou" => Ok(ObjectClass::OU),
             b"system" => Ok(ObjectClass::System),
             b"host" => Ok(ObjectClass::Host),
-            _ => Err(Error::NotFoundError),
+            _ => Err(Error::NotFound),
         }
     }
 }


### PR DESCRIPTION
Move Error into error::Error

Also remove "*Error" from the end of all error names, and implement the std::error::Error trait on our Error type.
