### PR TITLE
Get rid of OobData in blocks

### DIFF
--- a/src/lmdb_adapter.rs
+++ b/src/lmdb_adapter.rs
@@ -244,7 +244,7 @@ impl<'a> RwTransaction<'a> {
 mod tests {
     use adapter::{Adapter, Transaction};
     use error::Error;
-    use log::{self, Block};
+    use log;
     use objectclass::ObjectClass;
     use server::{Id, Path};
     use lmdb_adapter::LmdbAdapter;
@@ -285,7 +285,7 @@ mod tests {
                 .unwrap();
 
             let hosts_id = domain_id.next();
-            adapter.add_entry(&mut txn, hosts_id, domain_id, "hosts", ObjectClass::OU).unwrap();
+            adapter.add_entry(&mut txn, hosts_id, domain_id, "hosts", ObjectClass::Ou).unwrap();
 
             let host_id = hosts_id.next();
             adapter.add_entry(&mut txn,

--- a/src/objectclass.rs
+++ b/src/objectclass.rs
@@ -8,7 +8,8 @@ use objecthash::ObjectHash;
 pub enum ObjectClass {
     Root, // Root DSE
     Domain, // ala DNS domain or Kerberos realm
-    OU, // Organizational unit
+    Ou, // Organizational unit
+    Credential, // Encrypted access credential
     System, // System User (i.e. non-human account)
     Host, // an individual server
 }
@@ -18,7 +19,8 @@ impl ObjectClass {
         match bytes {
             b"root" => Ok(ObjectClass::Root),
             b"domain" => Ok(ObjectClass::Domain),
-            b"ou" => Ok(ObjectClass::OU),
+            b"ou" => Ok(ObjectClass::Ou),
+            b"credential" => Ok(ObjectClass::Credential),
             b"system" => Ok(ObjectClass::System),
             b"host" => Ok(ObjectClass::Host),
             _ => Err(Error::NotFound),
@@ -31,9 +33,10 @@ impl ToString for ObjectClass {
         match *self {
             ObjectClass::Root => "root".to_string(),
             ObjectClass::Domain => "domain".to_string(),
-            ObjectClass::OU => "ou".to_string(),
-            ObjectClass::Host => "host".to_string(),
+            ObjectClass::Ou => "ou".to_string(),
+            ObjectClass::Credential => "credential".to_string(),
             ObjectClass::System => "system".to_string(),
+            ObjectClass::Host => "host".to_string(),
         }
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -15,6 +15,8 @@ use signature::{SignatureAlgorithm, KeyPair};
 #[cfg(test)]
 extern crate tempdir;
 
+const DEFAULT_GENESIS_MESSAGE: &'static str = "Initial block";
+
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub struct Id(u64);
 
@@ -185,6 +187,7 @@ impl Server {
                                                  &admin_username,
                                                  &admin_keypair,
                                                  &admin_keypair_sealed,
+                                                 DEFAULT_GENESIS_MESSAGE,
                                                  DigestAlgorithm::SHA256);
 
         let adapter = LmdbAdapter::create_database(path).unwrap();


### PR DESCRIPTION
Instead prefer to just store it in the DIT. Access can be restricted.
