### PR TITLE
Entry Metadata

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -1,8 +1,8 @@
 use block::Block;
 use direntry::DirEntry;
-use entry::{self, Entry};
+use entry;
 use error::Result;
-use objectclass::ObjectClass;
+use metadata::Metadata;
 use path::Path;
 
 pub trait Transaction<D> {
@@ -21,8 +21,9 @@ pub trait Adapter<'a, D, R: Transaction<D>, W: Transaction<D>> {
                      id: entry::Id,
                      parent_id: entry::Id,
                      name: &'b str,
-                     objectclass: ObjectClass)
-                     -> Result<Entry>;
+                     metadata: &Metadata,
+                     data: &[u8])
+                     -> Result<DirEntry>;
     fn find_direntry<'b, T: Transaction<D>>(&'b self, txn: &'b T, path: &Path) -> Result<DirEntry>;
-    fn find_entry<'b, T: Transaction<D>>(&'b self, txn: &'b T, path: &Path) -> Result<Entry>;
+    fn find_entry<'b, T: Transaction<D>>(&'b self, txn: &'b T, id: &entry::Id) -> Result<&[u8]>;
 }

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,7 +1,7 @@
 use std::io;
 use std::string::ToString;
 
-use buffoon::{OutputStream, Serialize};
+use buffoon::{self, OutputStream, Serialize};
 use ring::digest;
 use rustc_serialize::base64::{self, ToBase64};
 use serde_json;
@@ -154,6 +154,10 @@ impl Block {
         let mut signature = [0u8; 64];
         signature.copy_from_slice(&keypair.sign(id.as_ref()).as_slice());
         self.signature = Some(signature);
+    }
+
+    pub fn to_proto(&self) -> Result<Vec<u8>> {
+        buffoon::serialize(&self).map_err(|_| Error::Serialize)
     }
 
     pub fn to_json(&self) -> String {

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -1,17 +1,9 @@
 use std::mem;
 
-use direntry::DirEntry;
 use error::{Error, Result};
-use objectclass::ObjectClass;
 
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub struct Id(u64);
-
-#[derive(Debug, Eq, PartialEq)]
-pub struct Entry<'a> {
-    pub direntry: DirEntry<'a>,
-    pub objectclass: ObjectClass,
-}
 
 // Ids are 64-bit integers in host-native byte order
 // LMDB has special optimizations for host-native integers as keys

--- a/src/lmdb_adapter.rs
+++ b/src/lmdb_adapter.rs
@@ -6,22 +6,22 @@ extern crate tempdir;
 
 use std::{self, str};
 
-use buffoon;
 use self::lmdb::{Environment, Database, DatabaseFlags, Cursor, WriteFlags, DUP_SORT, INTEGER_KEY};
 use self::lmdb::Transaction as LmdbTransaction;
 
 use adapter::{Adapter, Transaction};
 use block::Block;
 use direntry::DirEntry;
-use entry::{self, Entry};
+use entry;
 use error::{Error, Result};
-use objectclass::ObjectClass;
+use metadata::Metadata;
 use path::Path;
 
 pub struct LmdbAdapter {
     env: Environment,
     blocks: Database,
     directories: Database,
+    metadata: Database,
     entries: Database,
 }
 
@@ -41,6 +41,9 @@ impl LmdbAdapter {
         let directories = try!(env.create_db(Some("directories"), INTEGER_KEY | DUP_SORT)
             .map_err(|_| Error::DbCreate));
 
+        let metadata = try!(env.create_db(Some("metadata"), INTEGER_KEY)
+            .map_err(|_| Error::DbCreate));
+
         let entries = try!(env.create_db(Some("entries"), INTEGER_KEY)
             .map_err(|_| Error::DbCreate));
 
@@ -48,6 +51,7 @@ impl LmdbAdapter {
             env: env,
             blocks: blocks,
             directories: directories,
+            metadata: metadata,
             entries: entries,
         })
     }
@@ -58,15 +62,15 @@ impl LmdbAdapter {
             .map_err(|_| Error::DbOpen));
 
         let blocks = try!(env.open_db(Some("blocks")).map_err(|_| Error::DbOpen));
-
         let directories = try!(env.open_db(Some("directories")).map_err(|_| Error::DbOpen));
-
+        let metadata = try!(env.open_db(Some("metadata")).map_err(|_| Error::DbOpen));
         let entries = try!(env.open_db(Some("entries")).map_err(|_| Error::DbOpen));
 
         Ok(LmdbAdapter {
             env: env,
             blocks: blocks,
             directories: directories,
+            metadata: metadata,
             entries: entries,
         })
     }
@@ -76,8 +80,7 @@ impl LmdbAdapter {
                                                       parent_id: entry::Id,
                                                       name: &str)
                                                       -> Result<DirEntry> {
-        let direntry_bytes =
-            try!(txn.find(self.directories, parent_id.as_ref(), |direntry_bytes| {
+        let direntry_bytes = try!(txn.find(self.directories, parent_id.as_ref(), |direntry_bytes| {
                 match DirEntry::new(parent_id, direntry_bytes) {
                     Ok(direntry) => direntry.name == name,
                     _ => false,
@@ -120,13 +123,11 @@ impl<'a> Adapter<'a, lmdb::Database, RoTransaction<'a>, RwTransaction<'a>> for L
         // TODO: Don't Panic
         let block_id = block.id.expect("block ID unset");
 
-        let serialized = try!(buffoon::serialize(&block).map_err(|_| Error::Serialize));
-
         if txn.get(self.blocks, block_id.as_ref()) != Err(Error::NotFound) {
             return Err(Error::EntryAlreadyExists);
         }
 
-        try!(txn.put(self.blocks, block_id.as_ref(), &serialized)
+        try!(txn.put(self.blocks, block_id.as_ref(), &try!(block.to_proto()))
             .map_err(|_| Error::DbWrite));
 
         Ok(())
@@ -137,8 +138,9 @@ impl<'a> Adapter<'a, lmdb::Database, RoTransaction<'a>, RwTransaction<'a>> for L
                      id: entry::Id,
                      parent_id: entry::Id,
                      name: &'b str,
-                     objectclass: ObjectClass)
-                     -> Result<Entry> {
+                     metadata: &Metadata,
+                     data: &[u8])
+                     -> Result<DirEntry> {
         if txn.get(self.entries, id.as_ref()) != Err(Error::NotFound) {
             return Err(Error::EntryAlreadyExists);
         }
@@ -154,20 +156,16 @@ impl<'a> Adapter<'a, lmdb::Database, RoTransaction<'a>, RwTransaction<'a>> for L
             name: name,
         };
 
-        try!(txn.put(self.directories,
-                 parent_id.as_ref(),
-                 &direntry.to_bytes())
+        try!(txn.put(self.directories, parent_id.as_ref(), &direntry.to_bytes())
             .map_err(|_| Error::DbWrite));
 
-        try!(txn.put(self.entries,
-                 id.as_ref(),
-                 &objectclass.to_string().as_bytes())
+        try!(txn.put(self.metadata, id.as_ref(), &try!(metadata.to_proto()))
             .map_err(|_| Error::DbWrite));
 
-        Ok(Entry {
-            direntry: direntry,
-            objectclass: objectclass,
-        })
+        try!(txn.put(self.entries, id.as_ref(), data)
+            .map_err(|_| Error::DbWrite));
+
+        Ok(direntry)
     }
 
     fn find_direntry<'b, T: Transaction<lmdb::Database>>(&'b self,
@@ -181,19 +179,9 @@ impl<'a> Adapter<'a, lmdb::Database, RoTransaction<'a>, RwTransaction<'a>> for L
 
     fn find_entry<'b, T: Transaction<lmdb::Database>>(&'b self,
                                                       txn: &'b T,
-                                                      path: &Path)
-                                                      -> Result<Entry> {
-        let direntry = try!(self.find_direntry(txn, path));
-
-        let entry_bytes = try!(txn.get(self.entries, direntry.id.as_ref())
-            .map_err(|_| Error::DbCorrupt));
-
-        let objectclass = try!(ObjectClass::from_bytes(&entry_bytes).map_err(|_| Error::DbCorrupt));
-
-        Ok(Entry {
-            direntry: direntry,
-            objectclass: objectclass,
-        })
+                                                      id: &entry::Id)
+                                                      -> Result<&[u8]> {
+        txn.get(self.entries, id.as_ref()).map_err(|_| Error::NotFound)
     }
 }
 
@@ -251,6 +239,7 @@ mod tests {
     use entry::Id;
     use error::Error;
     use lmdb_adapter::LmdbAdapter;
+    use metadata::Metadata;
     use objectclass::ObjectClass;
     use path::Path;
 
@@ -259,6 +248,10 @@ mod tests {
     fn create_database() -> LmdbAdapter {
         let dir = TempDir::new("ithos-test").unwrap();
         LmdbAdapter::create_database(dir.path()).unwrap()
+    }
+
+    fn example_metadata(objectclass: ObjectClass) -> Metadata {
+        Metadata::new(objectclass, block::Id::root(), 42)
     }
 
     #[test]
@@ -278,6 +271,7 @@ mod tests {
     #[test]
     fn test_entry_lookup() {
         let adapter = create_database();
+        let example_data = b"some data we stored in the host entry";
 
         {
             let mut txn = adapter.rw_transaction().unwrap();
@@ -287,18 +281,26 @@ mod tests {
                            domain_id,
                            Id::root(),
                            "example.com",
-                           ObjectClass::Domain)
+                           &example_metadata(ObjectClass::Domain),
+                           b"")
                 .unwrap();
 
             let hosts_id = domain_id.next();
-            adapter.add_entry(&mut txn, hosts_id, domain_id, "hosts", ObjectClass::Ou).unwrap();
+            adapter.add_entry(&mut txn,
+                           hosts_id,
+                           domain_id,
+                           "hosts",
+                           &example_metadata(ObjectClass::Ou),
+                           b"")
+                .unwrap();
 
             let host_id = hosts_id.next();
             adapter.add_entry(&mut txn,
                            host_id,
                            hosts_id,
                            "master.example.com",
-                           ObjectClass::Host)
+                           &example_metadata(ObjectClass::Host),
+                           example_data)
                 .unwrap();
 
             txn.commit().unwrap();
@@ -309,11 +311,13 @@ mod tests {
 
             {
                 let path = Path::new("/example.com/hosts/master.example.com").unwrap();
-                let entry = adapter.find_entry(&txn, &path)
-                    .unwrap();
 
-                assert_eq!(entry.direntry.name, "master.example.com");
-                assert_eq!(entry.objectclass, ObjectClass::Host);
+                let direntry = adapter.find_direntry(&txn, &path).unwrap();
+                assert_eq!(direntry.name, "master.example.com");
+
+
+                let entry = adapter.find_entry(&txn, &direntry.id).unwrap();
+                assert_eq!(entry, &example_data[..]);
             }
 
             txn.commit().unwrap();
@@ -331,14 +335,17 @@ mod tests {
                        domain_id,
                        Id::root(),
                        "example.com",
-                       ObjectClass::Domain)
+                       &example_metadata(ObjectClass::Domain),
+                       b"")
             .unwrap();
 
         let result = adapter.add_entry(&mut txn,
                                        domain_id,
                                        Id::root(),
                                        "another.com",
-                                       ObjectClass::Domain);
+                                       &example_metadata(ObjectClass::Domain),
+                                       b"");
+
         assert_eq!(result, Err(Error::EntryAlreadyExists));
     }
 
@@ -353,14 +360,16 @@ mod tests {
                        domain_id,
                        Id::root(),
                        "example.com",
-                       ObjectClass::Domain)
+                       &example_metadata(ObjectClass::Domain),
+                       b"")
             .unwrap();
 
         let result = adapter.add_entry(&mut txn,
                                        domain_id.next(),
                                        Id::root(),
                                        "example.com",
-                                       ObjectClass::Domain);
+                                       &example_metadata(ObjectClass::Domain),
+                                       b"");
 
         assert_eq!(result, Err(Error::EntryAlreadyExists));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod direntry;
 mod entry;
 mod error;
 mod lmdb_adapter;
+mod metadata;
 mod objectclass;
 mod objecthash;
 mod op;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,0 +1,45 @@
+use std::io;
+
+use buffoon::{self, OutputStream, Serialize};
+
+use block;
+use error::{Error, Result};
+use objectclass::ObjectClass;
+
+pub struct Metadata {
+    pub objectclass: ObjectClass,
+    pub created_id: block::Id,
+    pub updated_id: block::Id,
+    pub created_at: u64,
+    pub updated_at: u64,
+    pub version: u64,
+}
+
+impl Metadata {
+    pub fn new(objectclass: ObjectClass, id: block::Id, timestamp: u64) -> Metadata {
+        Metadata {
+            objectclass: objectclass,
+            created_id: id,
+            updated_id: id,
+            created_at: timestamp,
+            updated_at: timestamp,
+            version: 0,
+        }
+    }
+
+    pub fn to_proto(&self) -> Result<Vec<u8>> {
+        buffoon::serialize(&self).map_err(|_| Error::Serialize)
+    }
+}
+
+impl Serialize for Metadata {
+    fn serialize<O: OutputStream>(&self, out: &mut O) -> io::Result<()> {
+        try!(out.write(1, &(self.objectclass as u32 + 1)));
+        try!(out.write(2, self.created_id.as_ref()));
+        try!(out.write(3, self.updated_id.as_ref()));
+        try!(out.write(4, &self.created_at));
+        try!(out.write(5, &self.updated_at));
+        try!(out.write(6, &self.version));
+        Ok(())
+    }
+}

--- a/src/objectclass.rs
+++ b/src/objectclass.rs
@@ -14,20 +14,6 @@ pub enum ObjectClass {
     Host, // an individual server
 }
 
-impl ObjectClass {
-    pub fn from_bytes(bytes: &[u8]) -> Result<ObjectClass> {
-        match bytes {
-            b"root" => Ok(ObjectClass::Root),
-            b"domain" => Ok(ObjectClass::Domain),
-            b"ou" => Ok(ObjectClass::Ou),
-            b"credential" => Ok(ObjectClass::Credential),
-            b"system" => Ok(ObjectClass::System),
-            b"host" => Ok(ObjectClass::Host),
-            _ => Err(Error::NotFound),
-        }
-    }
-}
-
 impl ToString for ObjectClass {
     fn to_string(&self) -> String {
         match *self {

--- a/src/proto/metadata.proto
+++ b/src/proto/metadata.proto
@@ -1,0 +1,13 @@
+package ithos;
+
+import "objectclass.proto";
+
+// Metadata associated with an ithos entry
+message Metadata {
+  required ObjectClass objectclass = 1;
+  required bytes       created_id = 2;
+  required bytes       updated_id = 3;
+  required uint64      created_at = 4;
+  required uint64      updated_at = 5;
+  required uint64      version    = 6;
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -8,6 +8,7 @@ use block::{Block, DigestAlgorithm};
 use entry;
 use error::{Error, Result};
 use lmdb_adapter::LmdbAdapter;
+use metadata::Metadata;
 use op::OpType;
 use password::{self, PasswordAlgorithm};
 use signature::{SignatureAlgorithm, KeyPair};
@@ -77,9 +78,12 @@ impl Server {
                     };
 
                     let name = op.path.name();
+                    let metadata = Metadata::new(op.objectclass,
+                                                 block.id.expect("block id missing"),
+                                                 block.timestamp);
 
                     // NOTE: The underlying adapter must handle Error::EntryAlreadyExists
-                    try!(self.adapter.add_entry(&mut txn, id, parent_id, &name, op.objectclass));
+                    try!(self.adapter.add_entry(&mut txn, id, parent_id, &name, &metadata, b""));
                     new_entries.insert(&op.path, id);
                     id = id.next()
                 }


### PR DESCRIPTION
Tracks stat-like metadata for each entry in the directory, including:
- ObjectClass
- created_id: block::Id
- updated_id: block::Id
- created_at: u64 timestamp
- updated_at: u64 timestamp
- version: number of times an entry has been modified
