### PR TITLE
Adapter::find_metadata

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -25,5 +25,9 @@ pub trait Adapter<'a, D, R: Transaction<D>, W: Transaction<D>> {
                      data: &[u8])
                      -> Result<DirEntry>;
     fn find_direntry<'b, T: Transaction<D>>(&'b self, txn: &'b T, path: &Path) -> Result<DirEntry>;
+    fn find_metadata<'b, T: Transaction<D>>(&'b self,
+                                            txn: &'b T,
+                                            id: &entry::Id)
+                                            -> Result<Metadata>;
     fn find_entry<'b, T: Transaction<D>>(&'b self, txn: &'b T, id: &entry::Id) -> Result<&[u8]>;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 extern crate clap;
 use clap::{App, Arg, SubCommand};
 
+#[macro_use]
 extern crate buffoon;
 extern crate ring;
 extern crate ring_pwhash as pwhash;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use buffoon::{self, OutputStream, Serialize};
+use buffoon::{self, Serialize, Deserialize, OutputStream, InputStream};
 
 use block;
 use error::{Error, Result};
@@ -27,6 +27,10 @@ impl Metadata {
         }
     }
 
+    pub fn from_proto(bytes: &[u8]) -> Result<Metadata> {
+        buffoon::deserialize(bytes).map_err(|_| Error::Parse)
+    }
+
     pub fn to_proto(&self) -> Result<Vec<u8>> {
         buffoon::serialize(&self).map_err(|_| Error::Serialize)
     }
@@ -41,5 +45,45 @@ impl Serialize for Metadata {
         try!(out.write(5, &self.updated_at));
         try!(out.write(6, &self.version));
         Ok(())
+    }
+}
+
+impl Deserialize for Metadata {
+    fn deserialize<R: io::Read>(i: &mut InputStream<R>) -> io::Result<Metadata> {
+        let mut objectclass = None;
+        let mut created_id_bytes: Option<Vec<u8>> = None;
+        let mut updated_id_bytes: Option<Vec<u8>> = None;
+        let mut created_at = None;
+        let mut updated_at = None;
+        let mut version = None;
+
+        while let Some(f) = try!(i.read_field()) {
+            match f.tag() {
+                1 => objectclass = Some(try!(f.read())),
+                2 => created_id_bytes = Some(try!(f.read())),
+                3 => updated_id_bytes = Some(try!(f.read())),
+                4 => created_at = Some(try!(f.read())),
+                5 => updated_at = Some(try!(f.read())),
+                6 => version = Some(try!(f.read())),
+                _ => try!(f.skip()),
+            }
+        }
+
+        let created_id = try!(block::Id::from_bytes(&required!(created_id_bytes,
+                                                               "Metadata::created_id"))
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "error parsing created_id")));
+
+        let updated_id = try!(block::Id::from_bytes(&required!(updated_id_bytes,
+                                                               "Metadata::updated_id"))
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "error parsing updated_id")));
+
+        Ok(Metadata {
+            objectclass: required!(objectclass, "Metadata::objectclass"),
+            created_id: created_id,
+            updated_id: updated_id,
+            created_at: required!(created_at, "Metadata::created_at"),
+            updated_at: required!(updated_at, "Metadata::updated_at"),
+            version: required!(version, "Metadata::version"),
+        })
     }
 }

--- a/src/objectclass.rs
+++ b/src/objectclass.rs
@@ -1,7 +1,9 @@
+use std::io;
 use std::string::ToString;
 use ring::digest::Digest;
 
-use error::{Error, Result};
+use buffoon::{Serialize, Deserialize, OutputStream, InputStream, Field};
+
 use objecthash::ObjectHash;
 
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
@@ -30,5 +32,33 @@ impl ToString for ObjectClass {
 impl ObjectHash for ObjectClass {
     fn objecthash(&self) -> Digest {
         self.to_string().objecthash()
+    }
+}
+
+impl Serialize for ObjectClass {
+    fn serialize<O: OutputStream>(&self, _: &mut O) -> io::Result<()> {
+        unimplemented!();
+    }
+
+    fn serialize_nested<O: OutputStream>(&self, field: u32, out: &mut O) -> io::Result<()> {
+        out.write_varint(field, *self as u32 + 1)
+    }
+}
+
+impl Deserialize for ObjectClass {
+    fn deserialize<R: io::Read>(_: &mut InputStream<R>) -> io::Result<ObjectClass> {
+        unimplemented!();
+    }
+
+    fn deserialize_nested<R: io::Read>(field: Field<R>) -> io::Result<ObjectClass> {
+        match try!(u32::deserialize_nested(field)) {
+            1 => Ok(ObjectClass::Root),
+            2 => Ok(ObjectClass::Domain),
+            3 => Ok(ObjectClass::Ou),
+            4 => Ok(ObjectClass::Credential),
+            5 => Ok(ObjectClass::System),
+            6 => Ok(ObjectClass::Host),
+            _ => Err(io::Error::new(io::ErrorKind::InvalidInput, "unknown ObjectClass")),
+        }
     }
 }

--- a/src/op.rs
+++ b/src/op.rs
@@ -28,6 +28,16 @@ impl ToString for OpType {
     }
 }
 
+impl Serialize for OpType {
+    fn serialize<O: OutputStream>(&self, _: &mut O) -> io::Result<()> {
+        unimplemented!();
+    }
+
+    fn serialize_nested<O: OutputStream>(&self, field: u32, out: &mut O) -> io::Result<()> {
+        out.write_varint(field, *self as u32 + 1)
+    }
+}
+
 impl Op {
     pub fn new(optype: OpType, path: Path, objectclass: ObjectClass, data: &[u8]) -> Op {
         Op {
@@ -41,9 +51,9 @@ impl Op {
 
 impl Serialize for Op {
     fn serialize<O: OutputStream>(&self, out: &mut O) -> io::Result<()> {
-        try!(out.write(1, &(self.optype as u32 + 1)));
+        try!(out.write(1, &self.optype));
         try!(out.write(2, &self.path.to_string()));
-        try!(out.write(3, &(self.objectclass as u32 + 1)));
+        try!(out.write(3, &self.objectclass));
         try!(out.write(4, &self.data));
         Ok(())
     }


### PR DESCRIPTION
Support for reading metadata from the database adapter, including deserialization support for `Metadata`.
