### PR TITLE
Move op application to the "op" module

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -2,7 +2,7 @@ use std::hash::{Hash, Hasher};
 
 use error::{Error, Result};
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct Path {
     pub components: Vec<String>,
 }


### PR DESCRIPTION
It was previously in the "server" module, and I'd like to move everything out of there which isn't immediately involved in serving things.
