### PR TITLE
Convert ObjectClass to a sum type

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -4,6 +4,7 @@ use entry;
 use error::Result;
 use metadata::Metadata;
 use path::Path;
+use objectclass::ObjectClass;
 
 pub trait Transaction<D> {
     fn commit(self) -> Result<()>;
@@ -22,7 +23,7 @@ pub trait Adapter<'a, D, R: Transaction<D>, W: Transaction<D>> {
                      parent_id: entry::Id,
                      name: &'b str,
                      metadata: &Metadata,
-                     data: &[u8])
+                     objectclass: &ObjectClass)
                      -> Result<DirEntry>;
     fn find_direntry<'b, T: Transaction<D>>(&'b self, txn: &'b T, path: &Path) -> Result<DirEntry>;
     fn find_metadata<'b, T: Transaction<D>>(&'b self,

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -1,6 +1,9 @@
 use std::io;
 
 use buffoon::{Serialize, Deserialize, OutputStream, InputStream, Field};
+use ring::digest::Digest;
+
+use objecthash::ObjectHash;
 
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub enum DigestAlgorithm {
@@ -13,7 +16,19 @@ pub enum SignatureAlgorithm {
 }
 
 // TODO: Support more than one algorithm type per enum
-macro_rules! impl_algorithm (($algorithm:ident, $only:expr) => (
+macro_rules! impl_algorithm (($algorithm:ident, $only:expr, $string:expr) => (
+    impl ToString for $algorithm {
+        fn to_string(&self) -> String {
+            $string.to_string()
+        }
+    }
+
+    impl ObjectHash for $algorithm {
+        fn objecthash(&self) -> Digest {
+          self.to_string().objecthash()
+        }
+    }
+
     impl Serialize for $algorithm {
         fn serialize<O: OutputStream>(&self, _: &mut O) -> io::Result<()> {
             unimplemented!();
@@ -40,5 +55,5 @@ macro_rules! impl_algorithm (($algorithm:ident, $only:expr) => (
     }
 ));
 
-impl_algorithm!(DigestAlgorithm, DigestAlgorithm::SHA256);
-impl_algorithm!(SignatureAlgorithm, SignatureAlgorithm::Ed25519);
+impl_algorithm!(DigestAlgorithm, DigestAlgorithm::SHA256, "SHA256");
+impl_algorithm!(SignatureAlgorithm, SignatureAlgorithm::Ed25519, "Ed25519");

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,6 +1,9 @@
 use ring::rand::SecureRandom;
 
+use ring::digest::Digest;
+
 use error::{Error, Result};
+use objecthash::ObjectHash;
 
 pub const ID_SIZE: usize = 16;
 
@@ -30,5 +33,11 @@ impl AsRef<[u8]> for Id {
     #[inline(always)]
     fn as_ref(&self) -> &[u8] {
         &self.0
+    }
+}
+
+impl ObjectHash for Id {
+    fn objecthash(&self) -> Digest {
+        self.as_ref().objecthash()
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ mod objecthash;
 mod op;
 mod password;
 mod path;
+mod proto;
 mod server;
 mod signature;
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,13 +1,11 @@
 use std::io;
 
-use buffoon::{self, Serialize, Deserialize, OutputStream, InputStream};
+use buffoon::{Serialize, Deserialize, OutputStream, InputStream};
 
 use block;
-use error::{Error, Result};
-use objectclass;
+use proto::{FromProto, ToProto};
 
 pub struct Metadata {
-    pub objectclass: objectclass::Type,
     pub created_id: block::Id,
     pub updated_id: block::Id,
     pub created_at: u64,
@@ -16,9 +14,8 @@ pub struct Metadata {
 }
 
 impl Metadata {
-    pub fn new(objectclass: objectclass::Type, id: block::Id, timestamp: u64) -> Metadata {
+    pub fn new(id: block::Id, timestamp: u64) -> Metadata {
         Metadata {
-            objectclass: objectclass,
             created_id: id,
             updated_id: id,
             created_at: timestamp,
@@ -26,31 +23,24 @@ impl Metadata {
             version: 0,
         }
     }
-
-    pub fn from_proto(bytes: &[u8]) -> Result<Metadata> {
-        buffoon::deserialize(bytes).map_err(|_| Error::Parse)
-    }
-
-    pub fn to_proto(&self) -> Result<Vec<u8>> {
-        buffoon::serialize(&self).map_err(|_| Error::Serialize)
-    }
 }
+
+impl FromProto for Metadata {}
+impl ToProto for Metadata {}
 
 impl Serialize for Metadata {
     fn serialize<O: OutputStream>(&self, out: &mut O) -> io::Result<()> {
-        try!(out.write(1, &self.objectclass));
-        try!(out.write(2, self.created_id.as_ref()));
-        try!(out.write(3, self.updated_id.as_ref()));
-        try!(out.write(4, &self.created_at));
-        try!(out.write(5, &self.updated_at));
-        try!(out.write(6, &self.version));
+        try!(out.write(1, self.created_id.as_ref()));
+        try!(out.write(2, self.updated_id.as_ref()));
+        try!(out.write(3, &self.created_at));
+        try!(out.write(4, &self.updated_at));
+        try!(out.write(5, &self.version));
         Ok(())
     }
 }
 
 impl Deserialize for Metadata {
     fn deserialize<R: io::Read>(i: &mut InputStream<R>) -> io::Result<Metadata> {
-        let mut objectclass = None;
         let mut created_id_bytes: Option<Vec<u8>> = None;
         let mut updated_id_bytes: Option<Vec<u8>> = None;
         let mut created_at = None;
@@ -59,12 +49,11 @@ impl Deserialize for Metadata {
 
         while let Some(f) = try!(i.read_field()) {
             match f.tag() {
-                1 => objectclass = Some(try!(f.read())),
-                2 => created_id_bytes = Some(try!(f.read())),
-                3 => updated_id_bytes = Some(try!(f.read())),
-                4 => created_at = Some(try!(f.read())),
-                5 => updated_at = Some(try!(f.read())),
-                6 => version = Some(try!(f.read())),
+                1 => created_id_bytes = Some(try!(f.read())),
+                2 => updated_id_bytes = Some(try!(f.read())),
+                3 => created_at = Some(try!(f.read())),
+                4 => updated_at = Some(try!(f.read())),
+                5 => version = Some(try!(f.read())),
                 _ => try!(f.skip()),
             }
         }
@@ -78,7 +67,6 @@ impl Deserialize for Metadata {
             .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "error parsing updated_id")));
 
         Ok(Metadata {
-            objectclass: required!(objectclass, "Metadata::objectclass"),
             created_id: created_id,
             updated_id: updated_id,
             created_at: required!(created_at, "Metadata::created_at"),

--- a/src/objectclass/root.rs
+++ b/src/objectclass/root.rs
@@ -1,33 +1,31 @@
 use std::io;
 
-use buffoon::{self, Serialize, Deserialize, OutputStream, InputStream};
+use buffoon::{Serialize, Deserialize, OutputStream, InputStream};
+use ring::digest;
 
 use algorithm::DigestAlgorithm;
-use error::{Error, Result};
 use log;
-use objectclass::ObjectClass;
+use proto::ToProto;
+use objecthash::{ObjectHash, DIGEST_ALG};
 
-pub struct Root {
+#[derive(Debug, Eq, PartialEq)]
+pub struct RootObject {
     pub logid: log::Id,
     pub digest_alg: DigestAlgorithm,
 }
 
-impl Root {
-    pub fn new(logid: log::Id) -> Root {
-        Root {
+impl RootObject {
+    pub fn new(logid: log::Id) -> RootObject {
+        RootObject {
             logid: logid,
             digest_alg: DigestAlgorithm::SHA256,
         }
     }
 }
 
-impl ObjectClass for Root {
-    fn to_proto(&self) -> Result<Vec<u8>> {
-        buffoon::serialize(&self).map_err(|_| Error::Serialize)
-    }
-}
+impl ToProto for RootObject {}
 
-impl Serialize for Root {
+impl Serialize for RootObject {
     fn serialize<O: OutputStream>(&self, out: &mut O) -> io::Result<()> {
         try!(out.write(1, self.logid.as_ref()));
         try!(out.write(2, &self.digest_alg));
@@ -35,8 +33,8 @@ impl Serialize for Root {
     }
 }
 
-impl Deserialize for Root {
-    fn deserialize<R: io::Read>(i: &mut InputStream<R>) -> io::Result<Root> {
+impl Deserialize for RootObject {
+    fn deserialize<R: io::Read>(i: &mut InputStream<R>) -> io::Result<RootObject> {
         let mut logid_bytes: Option<Vec<u8>> = None;
         let mut digest_alg = None;
 
@@ -51,9 +49,26 @@ impl Deserialize for Root {
         let logid = try!(log::Id::from_bytes(&required!(logid_bytes, "Root::logid"))
             .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "error parsing logid")));
 
-        Ok(Root {
+        Ok(RootObject {
             logid: logid,
             digest_alg: required!(digest_alg, "Root::digest_alg"),
         })
+    }
+}
+
+impl ObjectHash for RootObject {
+    fn objecthash(&self) -> digest::Digest {
+        let mut ctx = digest::Context::new(&DIGEST_ALG);
+
+        // objecthash qualifier for dictionaries
+        ctx.update(b"d");
+
+        ctx.update("logid".objecthash().as_ref());
+        ctx.update(self.logid.objecthash().as_ref());
+
+        ctx.update("digest_alg".objecthash().as_ref());
+        ctx.update(self.digest_alg.objecthash().as_ref());
+
+        ctx.finish()
     }
 }

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -1,0 +1,17 @@
+use std::marker::Sized;
+
+use buffoon::{self, Serialize, Deserialize};
+
+use error::{Error, Result};
+
+pub trait FromProto where Self: Sized + Deserialize {
+    fn from_proto(bytes: &[u8]) -> Result<Self> {
+        buffoon::deserialize(bytes).map_err(|_| Error::Parse)
+    }
+}
+
+pub trait ToProto where Self: Sized + Serialize {
+    fn to_proto(&self) -> Result<Vec<u8>> {
+        buffoon::serialize(&self).map_err(|_| Error::Serialize)
+    }
+}

--- a/src/proto/metadata.proto
+++ b/src/proto/metadata.proto
@@ -1,13 +1,10 @@
 package ithos;
 
-import "objectclass.proto";
-
 // Metadata associated with an ithos entry
 message Metadata {
-  required ObjectClass objectclass = 1;
-  required bytes       created_id = 2;
-  required bytes       updated_id = 3;
-  required uint64      created_at = 4;
-  required uint64      updated_at = 5;
-  required uint64      version    = 6;
+  required bytes  created_id = 1;
+  required bytes  updated_id = 2;
+  required uint64 created_at = 3;
+  required uint64 updated_at = 4;
+  required uint64 version    = 5;
 }

--- a/src/proto/objectclass.proto
+++ b/src/proto/objectclass.proto
@@ -1,10 +1,15 @@
 package ithos;
 
-enum ObjectClass {
-  ROOT = 1;       // Root DSE
-  DOMAIN = 2;     // ala DNS domain or Kerberos realm
-  OU = 3;         // Organizational unit
-  CREDENTIAL = 4; // Encrypted access credentials
-  SYSTEM = 5;     // System User (i.e. non-human account)
-  HOST = 6;       // an individual server
+message ObjectClass {
+  enum Type {
+    ROOT = 1;       // Root DSE
+    DOMAIN = 2;     // ala DNS domain or Kerberos realm
+    OU = 3;         // Organizational unit
+    CREDENTIAL = 4; // Encrypted access credentials
+    SYSTEM = 5;     // System User (i.e. non-human account)
+    HOST = 6;       // an individual server
+  }
+
+  required Type type = 1;
+  required bytes value = 2;
 }

--- a/src/proto/op.proto
+++ b/src/proto/op.proto
@@ -11,5 +11,4 @@ message Op {
   required Type        optype = 1;
   required string      path = 2;
   optional ObjectClass objectclass = 3;
-  optional bytes       data = 4;
 }


### PR DESCRIPTION
This changes the ObjectClass enum into a sum type where each class type holds a reference to a corresponding object struct.

This seems like an improvement for writing APIs which deal generically with typed entries in the DIT.

Otherwise, I hope I don't come to regret this.
