### PR TITLE
Use associated types with Adapter API

### DIFF
--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -8,29 +8,42 @@ use metadata::Metadata;
 use path::Path;
 use objectclass::ObjectClass;
 
-pub trait Transaction<D> {
+pub trait Transaction {
+    type D;
+
     fn commit(self) -> Result<()>;
-    fn get(&self, database: D, key: &[u8]) -> Result<&[u8]>;
-    fn find<P>(&self, db: D, key: &[u8], predicate: P) -> Result<&[u8]> where P: Fn(&[u8]) -> bool;
+    fn get(&self, db: Self::D, key: &[u8]) -> Result<&[u8]>;
+    fn find<P>(&self, db: Self::D, key: &[u8], predicate: P) -> Result<&[u8]>
+        where P: Fn(&[u8]) -> bool;
 }
 
-pub trait Adapter<'a, D, R: Transaction<D>, W: Transaction<D>> {
-    fn ro_transaction(&'a self) -> Result<R>;
-    fn rw_transaction(&'a self) -> Result<W>;
-    fn next_free_entry_id(&self, txn: &W) -> Result<entry::Id>;
-    fn add_block<'b>(&'b self, txn: &'b mut W, block: &Block) -> Result<()>;
+pub trait Adapter<'a> {
+    type D;
+    type R: Transaction<D = Self::D>;
+    type W: Transaction<D = Self::D>;
+
+    fn ro_transaction(&'a self) -> Result<Self::R>;
+    fn rw_transaction(&'a self) -> Result<Self::W>;
+    fn next_free_entry_id(&self, txn: &Self::W) -> Result<entry::Id>;
+    fn add_block<'b>(&'b self, txn: &'b mut Self::W, block: &Block) -> Result<()>;
     fn add_entry<'b>(&'b self,
-                     txn: &'b mut W,
+                     txn: &'b mut Self::W,
                      id: entry::Id,
                      parent_id: entry::Id,
                      name: &'b str,
                      metadata: &Metadata,
                      objectclass: &ObjectClass)
                      -> Result<DirEntry>;
-    fn find_direntry<'b, T: Transaction<D>>(&'b self, txn: &'b T, path: &Path) -> Result<DirEntry>;
-    fn find_metadata<'b, T: Transaction<D>>(&'b self,
-                                            txn: &'b T,
-                                            id: &entry::Id)
-                                            -> Result<Metadata>;
-    fn find_entry<'b, T: Transaction<D>>(&'b self, txn: &'b T, id: &entry::Id) -> Result<&[u8]>;
+    fn find_direntry<'b, T: Transaction<D = Self::D>>(&'b self,
+                                                      txn: &'b T,
+                                                      path: &Path)
+                                                      -> Result<DirEntry>;
+    fn find_metadata<'b, T: Transaction<D = Self::D>>(&'b self,
+                                                      txn: &'b T,
+                                                      id: &entry::Id)
+                                                      -> Result<Metadata>;
+    fn find_entry<'b, T: Transaction<D = Self::D>>(&'b self,
+                                                   txn: &'b T,
+                                                   id: &entry::Id)
+                                                   -> Result<&[u8]>;
 }


### PR DESCRIPTION
Adapters and their associated transactions are tightly coupled, so we can use associated types to greatly reduce the complexity of the Adapter trait's type signature.
