### PR TITLE
OrganizationalUnitObject

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -11,6 +11,7 @@ use algorithm::DigestAlgorithm;
 use error::{Error, Result};
 use log;
 use objectclass::ObjectClass;
+use objectclass::ou::OrganizationalUnitObject;
 use objectclass::root::RootObject;
 use objecthash::{self, ObjectHash, ObjectHasher};
 use op::{Op, OpType};
@@ -87,7 +88,10 @@ impl Block {
                          Path::new("/").unwrap(),
                          ObjectClass::Root(RootObject::new(*logid))));
 
-        ops.push(Op::new(OpType::Add, Path::new("/system").unwrap(), ObjectClass::Ou));
+        let system_ou = OrganizationalUnitObject::new(Some(String::from("Core system users")));
+        ops.push(Op::new(OpType::Add,
+                         Path::new("/system").unwrap(),
+                         ObjectClass::OrganizationalUnit(system_ou)));
 
         let public_key_bytes = admin_keypair.public_key_bytes();
 

--- a/src/objectclass/ou.rs
+++ b/src/objectclass/ou.rs
@@ -1,0 +1,60 @@
+use std::io;
+
+use buffoon::{Serialize, Deserialize, OutputStream, InputStream};
+
+use proto::ToProto;
+use objecthash::{self, ObjectHash, ObjectHasher};
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct OrganizationalUnitObject {
+    pub description: Option<String>,
+}
+
+impl OrganizationalUnitObject {
+    pub fn new(description: Option<String>) -> OrganizationalUnitObject {
+        OrganizationalUnitObject { description: description }
+    }
+}
+
+impl ToProto for OrganizationalUnitObject {}
+
+impl Serialize for OrganizationalUnitObject {
+    fn serialize<O: OutputStream>(&self, out: &mut O) -> io::Result<()> {
+        match self.description {
+            Some(ref description) => try!(out.write(1, &description)),
+            None => (),
+        }
+
+        Ok(())
+    }
+}
+
+impl Deserialize for OrganizationalUnitObject {
+    fn deserialize<R: io::Read>(i: &mut InputStream<R>) -> io::Result<OrganizationalUnitObject> {
+        let mut description: Option<String> = None;
+
+        while let Some(f) = try!(i.read_field()) {
+            match f.tag() {
+                1 => description = Some(try!(f.read())),
+                _ => try!(f.skip()),
+            }
+        }
+
+        Ok(OrganizationalUnitObject { description: description })
+    }
+}
+
+impl ObjectHash for OrganizationalUnitObject {
+    #[inline]
+    fn objecthash<H: ObjectHasher>(&self, hasher: &mut H) {
+        match self.description {
+            Some(ref desc) => {
+                objecthash_struct!(
+                    hasher,
+                    "description" => *desc
+                )
+            }
+            None => (),
+        }
+    }
+}

--- a/src/proto/objectclass.proto
+++ b/src/proto/objectclass.proto
@@ -2,12 +2,12 @@ package ithos;
 
 message ObjectClass {
   enum Type {
-    ROOT = 1;       // Root DSE
-    DOMAIN = 2;     // ala DNS domain or Kerberos realm
-    OU = 3;         // Organizational unit
-    CREDENTIAL = 4; // Encrypted access credentials
-    SYSTEM = 5;     // System User (i.e. non-human account)
-    HOST = 6;       // an individual server
+    ROOT = 1;                // Root entry in the tree (ala LDAP root DSE)
+    DOMAIN = 2;              // Administrative Domain (ala DNS domain or Kerberos realm)
+    ORGANIZATIONAL_UNIT = 3; // Unit/department within an organization or other logical grouping
+    CREDENTIAL = 4;          // Encrypted access credentials
+    SYSTEM = 5;              // System User (i.e. non-human account)
+    HOST = 6;                // Individual server within a domain
   }
 
   required Type type = 1;

--- a/src/proto/objectclass/organizational_unit.proto
+++ b/src/proto/objectclass/organizational_unit.proto
@@ -1,0 +1,6 @@
+package ithos.objectclass;
+
+// Organizational Unit
+message OrganizationalUnit {
+    optional string description = 1;
+}

--- a/src/proto/objectclass/root.proto
+++ b/src/proto/objectclass/root.proto
@@ -1,6 +1,6 @@
 package ithos.objectclass;
 
-import "algorithm.proto";
+
 
 // Root entry of the directory tree (Root DSE in LDAP parlance)
 //


### PR DESCRIPTION
Adds a type (part of the ObjectClass tagged union) for modelling Organizational Units (a.k.a. "OUs")

OUs represent logical groups within an organization, such as a department, or more abstract groups, e.g. "people" or "system users"
