### PR TITLE
Use a weaker set of scrypt parameters for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: rust
 sudo: false
 
-script: cargo test --verbose --release
-
 branches:
   only:
     - master

--- a/src/password.rs
+++ b/src/password.rs
@@ -6,9 +6,17 @@ pub enum PasswordAlgorithm {
     SCRYPT,
 }
 
+#[cfg(not(test))]
 #[inline(always)]
 fn params() -> ScryptParams {
     ScryptParams::new(16, 8, 1)
+}
+
+// Use a weak set of parameters when running tests to reduce test times
+// WARNING: do not use these params in release versions of this software!
+#[cfg(test)]
+fn params() -> ScryptParams {
+    ScryptParams::new(1, 1, 1)
 }
 
 pub fn derive(alg: PasswordAlgorithm, salt: &[u8], password: &str, out: &mut [u8]) {


### PR DESCRIPTION
Uses conditional compilation to gate scrypt parameters on whether or not we're running tests.

Includes an unsafe-but-fast set of parameters for testing purposes only.

This feels like the sort of thing that might come back and bite us on the ass. Hopefully not.
