### PR TITLE
Use published *ring* crate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,10 @@ os:
   - linux
   - osx
 
+matrix:
+  fast_finish: true
+  allow_failures:
+    - rust: nightly
+
 notifications:
   irc: 'irc.freenode.org#cryptosphere'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,14 +21,14 @@ time            = ">= 0.1.35"
 git = "https://github.com/carllerche/buffoon.git"
 
 [dependencies.objecthash]
-git = "https://github.com/cryptosphere/rust-objecthash.git"
+version = ">= 0.1.1"
 features = ["octet-strings"]
 
 [dependencies.ring]
-git = "https://github.com/briansmith/ring"
+version = ">= 0.2.3"
 
 [dependencies.ring-pwhash]
-git = "https://github.com/cryptosphere/ring-pwhash"
+version = ">= 0.1.0"
 
 [dev-dependencies]
 tempdir = "0.3"


### PR DESCRIPTION
This switches Cargo.toml to use published crates instead of git-based dependencies.

This is needed to fix a current Travis build failure, as ring-pwhash and objecthash switched to the _ring_ crate.
