### PR TITLE
Refactor Path -> {Path, PathBuf}

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ os:
 matrix:
   fast_finish: true
   allow_failures:
-    - rust: nightly
+    - rust: beta
 
 notifications:
   irc: 'irc.freenode.org#cryptosphere'

--- a/src/adapter/lmdb.rs
+++ b/src/adapter/lmdb.rs
@@ -175,7 +175,7 @@ impl<'a> Adapter<'a> for LmdbAdapter {
                                                        txn: &'b T,
                                                        path: &Path)
                                                        -> Result<DirEntry> {
-        path.components.iter().fold(Ok(DirEntry::root()), |parent_direntry, component| {
+        path.components().iter().fold(Ok(DirEntry::root()), |parent_direntry, component| {
             self.find_child(txn, try!(parent_direntry).id, component)
         })
     }

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,78 +1,210 @@
+use std::borrow::Borrow;
 use std::hash::{Hash, Hasher};
+use std::mem;
 
-use error::{Error, Result};
 use objecthash::{ObjectHash, ObjectHasher};
 
-#[derive(Debug, Eq, PartialEq, Clone)]
-pub struct Path {
-    pub components: Vec<String>,
+pub const SEPARATOR: &'static str = "/";
+
+// Builder for absolute paths
+#[derive(Clone)]
+pub struct PathBuf(String);
+
+impl PathBuf {
+    pub fn new() -> PathBuf {
+        PathBuf(String::from(SEPARATOR))
+    }
+
+    pub fn as_path(&self) -> &Path {
+        self.as_ref()
+    }
+
+    pub fn push<P: AsRef<str>>(&mut self, path: P) {
+        if !self.0.ends_with(SEPARATOR) {
+            self.0.push_str(SEPARATOR);
+        }
+
+        self.0.push_str(path.as_ref());
+    }
 }
 
-const SEPARATOR: &'static str = "/";
+impl From<String> for PathBuf {
+    fn from(s: String) -> PathBuf {
+        PathBuf(s)
+    }
+}
+
+impl AsRef<str> for PathBuf {
+    fn as_ref(&self) -> &str {
+        &self.0[..]
+    }
+}
+
+impl Into<String> for PathBuf {
+    fn into(self) -> String {
+        self.0
+    }
+}
+
+impl Borrow<Path> for PathBuf {
+    fn borrow(&self) -> &Path {
+        Path::new(&self.0).unwrap()
+    }
+}
+
+impl Hash for PathBuf {
+    fn hash<H: Hasher>(&self, h: &mut H) {
+        self.0.hash(h)
+    }
+}
+
+impl ObjectHash for PathBuf {
+    #[inline]
+    fn objecthash<H: ObjectHasher>(&self, hasher: &mut H) {
+        self.0.objecthash(hasher);
+    }
+}
+
+// Slices of absolute paths
+#[derive(Debug, Eq, PartialEq)]
+pub struct Path(str);
 
 impl Path {
-    pub fn new(string: &str) -> Result<Path> {
-        let mut components: Vec<String> =
-            string.split(SEPARATOR).map(|component| String::from(component)).collect();
-
-        if components.is_empty() {
-            return Err(Error::PathInvalid);
-        }
-
-        let prefix = components.remove(0);
-
-        // Does the path start with something other than "/"?
-        if !prefix.is_empty() {
-            return Err(Error::PathInvalid);
-        }
-
-        Ok(Path { components: components })
+    pub fn root() -> &'static Path {
+        Path::new(SEPARATOR).unwrap()
     }
 
-    pub fn parent(&self) -> Path {
-        if self.is_root() {
-            return Path { components: vec![String::from("")] };
+    pub fn new<S: AsRef<str> + ?Sized>(s: &S) -> Option<&Path> {
+        if s.as_ref().starts_with(SEPARATOR) {
+            Some(unsafe { mem::transmute(s.as_ref()) })
+        } else {
+            None
+        }
+    }
+
+    // TODO: replace Vec with Components type ala std::path
+    pub fn components(&self) -> Vec<&str> {
+        let mut result: Vec<&str> = self.0.split(SEPARATOR).collect();
+        result.remove(0);
+        result
+    }
+
+    pub fn parent(&self) -> Option<&Path> {
+        let result = self.0.rsplitn(2, SEPARATOR).last();
+
+        if result == Some("") {
+            if self == Path::root() {
+                return None;
+            } else {
+                return Some(Path::root());
+            }
         }
 
-        let mut parent_components = self.components.clone();
-        parent_components.pop();
-
-        Path { components: parent_components }
+        result.map(|component| Path::new(component).unwrap())
     }
 
-    pub fn name(&self) -> String {
-        self.components.last().unwrap().clone()
+    pub fn entry_name(&self) -> Option<&str> {
+        self.0.rsplitn(2, SEPARATOR).next()
     }
+}
 
-    pub fn is_root(&self) -> bool {
-        self.components.len() == 1 && self.components[0] == ""
+impl AsRef<str> for Path {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<Path> for Path {
+    fn as_ref(&self) -> &Path {
+        self
+    }
+}
+
+impl AsRef<Path> for PathBuf {
+    fn as_ref(&self) -> &Path {
+        &Path::new(&self.0).unwrap()
     }
 }
 
 impl ToString for Path {
     fn to_string(&self) -> String {
-        let mut result = String::new();
+        String::from(&self.0)
+    }
+}
 
-        for component in self.components.clone() {
-            result.push_str(SEPARATOR);
-            result.push_str(&component);
-        }
+impl ToOwned for Path {
+    type Owned = PathBuf;
 
-        result
+    fn to_owned(&self) -> PathBuf {
+        PathBuf(String::from(&self.0))
     }
 }
 
 impl Hash for Path {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        for component in &self.components {
-            component.hash(state);
-        }
+    fn hash<H: Hasher>(&self, h: &mut H) {
+        self.0.hash(h)
     }
 }
 
 impl ObjectHash for Path {
     #[inline]
     fn objecthash<H: ObjectHasher>(&self, hasher: &mut H) {
-        self.to_string().objecthash(hasher);
+        self.0.objecthash(hasher);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use path::{Path, PathBuf};
+
+    fn example_path() -> &'static Path {
+        Path::new("/foo/bar/baz").unwrap()
+    }
+
+    #[test]
+    fn pathbuf_inits_to_root() {
+        assert_eq!(PathBuf::new().as_path(), Path::root());
+    }
+
+    #[test]
+    fn pathbuf_push() {
+        let mut pathbuf = PathBuf::new();
+        pathbuf.push("foo");
+        pathbuf.push("bar");
+        pathbuf.push("baz");
+
+        assert_eq!(pathbuf.as_path(), example_path());
+    }
+
+    #[test]
+    fn path_parsing() {
+        // Absolute paths are ok
+        assert!(Path::new("/").is_some());
+        assert!(Path::new("/foo").is_some());
+        assert!(Path::new("/foo/bar").is_some());
+
+        // Empty paths are not ok
+        assert!(Path::new("").is_none());
+
+        // Relative paths are not ok
+        assert!(Path::new("../foo").is_none());
+    }
+
+    #[test]
+    fn path_parent() {
+        assert_eq!(Path::root().parent(), None);
+        assert_eq!(Path::new("/foo").unwrap().parent().unwrap(), Path::root());
+        assert_eq!(Path::new("/foo/bar").unwrap().parent().unwrap(),
+                   Path::new("/foo").unwrap());
+    }
+
+    #[test]
+    fn path_entry_name() {
+        assert_eq!(example_path().entry_name().unwrap(), "baz");
+    }
+
+    #[test]
+    fn path_components() {
+        assert_eq!(example_path().components(), vec!["foo", "bar", "baz"])
     }
 }


### PR DESCRIPTION
- Path is now a slice of an absolute path
- PathBuf is the corresponding owned type

Where possible, this tries to mimic std::path for familiarity's sake
