### PR TITLE
Global domain

### DIFF
--- a/src/adapter/lmdb.rs
+++ b/src/adapter/lmdb.rs
@@ -116,7 +116,7 @@ impl<'a> Adapter<'a> for LmdbAdapter {
         // Ensure the block we're adding is the next in the chain
         if block.parent_id == block::Id::zero() {
             if txn.get(self.state, LOG_ID_KEY) != Err(Error::NotFound) {
-                return Err(Error::EntryAlreadyExists)
+                return Err(Error::EntryAlreadyExists);
             }
 
             try!(txn.put(self.state, LOG_ID_KEY, block.id.as_ref()));

--- a/src/block.rs
+++ b/src/block.rs
@@ -9,6 +9,7 @@ use algorithm::{DigestAlgorithm, EncryptionAlgorithm, SignatureAlgorithm};
 use error::{Error, Result};
 use object::Object;
 use object::credential::CredentialEntry;
+use object::domain::DomainEntry;
 use object::ou::OrgUnitEntry;
 use object::root::RootEntry;
 use object::system::SystemEntry;
@@ -93,10 +94,17 @@ impl Block {
                          path.clone(),
                          Object::Root(RootEntry::new(digest_alg))));
 
-        let system_ou = OrgUnitEntry::new(Some(String::from("Core system users")));
+        let global_domain = DomainEntry::new(Some(String::from("Global system users and config")));
 
-        path.push("system");
-        ops.push(Op::new(op::Type::Add, path.clone(), Object::OrgUnit(system_ou)));
+        path.push("global");
+        ops.push(Op::new(op::Type::Add, path.clone(), Object::Domain(global_domain)));
+
+        let global_users_ou = OrgUnitEntry::new(Some(String::from("Core system users")));
+
+        path.push("users");
+        ops.push(Op::new(op::Type::Add,
+                         path.clone(),
+                         Object::OrgUnit(global_users_ou)));
 
         let admin_user = SystemEntry::new(String::from(admin_username));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,7 +131,8 @@ fn domain_add(database_path: &str, admin_username: &str, domain_name: &str) {
         });
 
     let mut keypair_path = PathBuf::new();
-    keypair_path.push("system");
+    keypair_path.push("global");
+    keypair_path.push("users");
     keypair_path.push(&admin_username);
     keypair_path.push("keys");
     keypair_path.push("signing");

--- a/src/object/root.rs
+++ b/src/object/root.rs
@@ -27,7 +27,6 @@ impl AllowsChild for RootEntry {
     #[inline]
     fn allows_child(child: &Object) -> bool {
         match *child {
-            Object::OrgUnit(_) => true,
             Object::Domain(_) => true,
             _ => false,
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -84,7 +84,7 @@ impl<A> Server<A>
                       description: Option<String>,
                       comment: &str)
                       -> Result<()> {
-        let domain_entry = DomainEntry { description: description };
+        let domain_entry = DomainEntry::new(description);
 
         let timestamp = Timestamp::now();
         let mut ops = Vec::new();
@@ -160,7 +160,8 @@ mod tests {
 
     fn admin_keypair(server: &Server<LmdbAdapter>) -> signature::KeyPair {
         let mut keypair_path = PathBuf::new();
-        keypair_path.push("system");
+        keypair_path.push("global");
+        keypair_path.push("users");
         keypair_path.push(ADMIN_USERNAME);
         keypair_path.push("keys");
         keypair_path.push("signing");


### PR DESCRIPTION
Moves global users and config into a global domain: /global

This allows the root directory to be constrained only to domains (for now)