### PR TITLE
Axe clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,4 +36,3 @@ version = ">= 0.3"
 
 [dev-dependencies]
 tempdir = "0.3"
-clippy = "0.0.98"

--- a/src/block.rs
+++ b/src/block.rs
@@ -73,7 +73,6 @@ impl Block {
     // This block contains the initial administrative signature key which will
     // be used as the initial root authority for new blocks in the log.
     // The block is self-signed with the initial administrator key.
-    #[allow(too_many_arguments)]
     pub fn initial_block(admin_username: &str,
                          admin_keypair: &KeyPair,
                          admin_keypair_sealed: &[u8],

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,6 @@
 #![crate_name = "ithos"]
 #![crate_type = "bin"]
 
-#![feature(plugin)]
-#![plugin(clippy)]
-
 extern crate clap;
 use clap::{App, Arg, SubCommand};
 

--- a/src/object/credential.rs
+++ b/src/object/credential.rs
@@ -65,7 +65,6 @@ pub struct CredentialEntry {
 }
 
 impl CredentialEntry {
-    #[allow(too_many_arguments)]
     pub fn from_signature_keypair(signature_alg: SignatureAlgorithm,
                                   sealing_alg: EncryptionAlgorithm,
                                   sealed_keypair: &[u8],

--- a/src/path.rs
+++ b/src/path.rs
@@ -9,7 +9,6 @@ pub const SEPARATOR: &'static str = "/";
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct PathBuf(String);
 
-#[allow(single_char_pattern)]
 impl PathBuf {
     pub fn new() -> PathBuf {
         PathBuf(String::from(SEPARATOR))
@@ -52,7 +51,6 @@ impl Borrow<Path> for PathBuf {
     }
 }
 
-#[allow(derive_hash_xor_eq)]
 impl Hash for PathBuf {
     fn hash<H: Hasher>(&self, h: &mut H) {
         self.0.hash(h)
@@ -70,7 +68,6 @@ impl ObjectHash for PathBuf {
 #[derive(Debug, Eq, PartialEq)]
 pub struct Path(str);
 
-#[allow(single_char_pattern)]
 impl Path {
     pub fn root() -> &'static Path {
         Path::new(SEPARATOR).unwrap()
@@ -146,7 +143,6 @@ impl ToOwned for Path {
     }
 }
 
-#[allow(derive_hash_xor_eq)]
 impl Hash for Path {
     fn hash<H: Hasher>(&self, h: &mut H) {
         self.0.hash(h)


### PR DESCRIPTION
It's been broken on nightlies for awhile. Now that most of the warnings have been fixed, we should probably remove it until it's stable again.