### PR TITLE
Upgrade to proto3

### DIFF
--- a/src/adapter/lmdb.rs
+++ b/src/adapter/lmdb.rs
@@ -282,7 +282,6 @@ impl From<LmdbError> for Error {
 
 #[cfg(test)]
 mod tests {
-
     use adapter::{Adapter, Transaction};
     use adapter::lmdb::LmdbAdapter;
     use block;

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -22,7 +22,7 @@ macro_rules! impl_algorithm (($algorithm:ident, $only:expr, $string:expr) => (
     impl $algorithm {
         #[allow(dead_code)]
         pub fn id(&self) -> u32 {
-            *self as u32 + 1
+            *self as u32
         }
     }
 
@@ -44,7 +44,7 @@ macro_rules! impl_algorithm (($algorithm:ident, $only:expr, $string:expr) => (
         }
 
         fn serialize_nested<O: OutputStream>(&self, field: u32, out: &mut O) -> io::Result<()> {
-            out.write_varint(field, *self as u32 + 1)
+            out.write_varint(field, *self as u32)
         }
     }
 
@@ -55,7 +55,7 @@ macro_rules! impl_algorithm (($algorithm:ident, $only:expr, $string:expr) => (
 
         fn deserialize_nested<R: io::Read>(field: Field<R>) -> io::Result<$algorithm> {
             match try!(u32::deserialize_nested(field)) {
-                1 => Ok($only),
+                0 => Ok($only),
                 _ => Err(io::Error::new(
                          io::ErrorKind::InvalidInput,
                          concat!("unknown algorithm"))),

--- a/src/block.rs
+++ b/src/block.rs
@@ -239,7 +239,7 @@ pub mod tests {
     const ADMIN_USERNAME: &'static str = "manager";
     const ADMIN_KEYPAIR_SEALED: &'static [u8] = b"placeholder";
     const ADMIN_KEYPAIR_SALT: &'static [u8] = b"NaCl";
-    const COMMENT: &'static str = "The tree of a thousand users begins with one block";
+    const COMMENT: &'static str = "The tree of a thousand users begins with a single block";
 
     pub fn example_block() -> Block {
         let rng = rand::SystemRandom::new();

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -4,6 +4,7 @@ use proto::{FromProto, ToProto};
 use std::io;
 use timestamp::Timestamp;
 
+#[derive(Debug, Eq, PartialEq)]
 pub struct Metadata {
     pub created_id: block::Id,
     pub updated_id: block::Id,

--- a/src/op.rs
+++ b/src/op.rs
@@ -34,7 +34,7 @@ impl Serialize for Type {
     }
 
     fn serialize_nested<O: OutputStream>(&self, field: u32, out: &mut O) -> io::Result<()> {
-        out.write_varint(field, *self as u32 + 1)
+        out.write_varint(field, *self as u32)
     }
 }
 
@@ -78,7 +78,7 @@ impl Op {
     pub fn build_json(&self, builder: ObjectBuilder) -> ObjectBuilder {
         builder.insert("optype", self.optype.to_string())
             .insert("path", self.path.as_path().to_string())
-            .insert_object("objectclass", |b| self.object.build_json(b))
+            .insert_object("object", |b| self.object.build_json(b))
     }
 
     fn add<'a, A>(&self,

--- a/src/proto/algorithm.proto
+++ b/src/proto/algorithm.proto
@@ -1,13 +1,15 @@
+syntax = "proto3";
+
 package ithos;
 
 enum DigestAlgorithm {
-    SHA256 = 1;
+    SHA256 = 0;
 }
 
 enum EncryptionAlgorithm {
-    AES256GCM = 1;
+    AES256GCM = 0;
 }
 
 enum SignatureAlgorithm {
-    Ed25519 = 1;
+    Ed25519 = 0;
 }

--- a/src/proto/block.proto
+++ b/src/proto/block.proto
@@ -1,3 +1,5 @@
+syntax = "proto3";
+
 package ithos;
 
 import "op.proto";
@@ -7,11 +9,11 @@ import "op.proto";
 // a signature) to carry them out. Some might call it a "blockchain",
 // but in Ithos it is referred to as the log
 message Block {
-  required bytes  id = 1;
-  required bytes  parent = 2;
-  required uint64 timestamp = 3;
-  repeated Op     ops = 4;
-  required string comment = 5;
-  required bytes  signed_by = 6;
-  required bytes  signature = 7;
+  bytes id         = 1;
+  bytes parent     = 2;
+  uint64 timestamp = 3;
+  repeated Op ops  = 4;
+  string comment   = 5;
+  bytes signed_by  = 6;
+  bytes signature  = 7;
 }

--- a/src/proto/metadata.proto
+++ b/src/proto/metadata.proto
@@ -1,10 +1,12 @@
+syntax = "proto3";
+
 package ithos;
 
 // Metadata associated with an ithos entry
 message Metadata {
-  required bytes  created_id = 1;
-  required bytes  updated_id = 2;
-  required uint64 created_at = 3;
-  required uint64 updated_at = 4;
-  required uint64 version    = 5;
+  bytes  created_id = 1;
+  bytes  updated_id = 2;
+  uint64 created_at = 3;
+  uint64 updated_at = 4;
+  uint64 version    = 5;
 }

--- a/src/proto/object.proto
+++ b/src/proto/object.proto
@@ -1,15 +1,19 @@
+syntax = "proto3";
+
 package ithos;
 
-message Object {
-  enum Class {
-    ROOT = 1;                // Root entry in the tree (ala LDAP root DSE)
-    DOMAIN = 2;              // Administrative Domain (ala DNS domain or Kerberos realm)
-    ORGANIZATIONAL_UNIT = 3; // Unit/department within an organization or other logical grouping
-    SYSTEM = 5;              // System User (i.e. non-human account)
-    CREDENTIAL = 4;          // Encrypted access credentials
-    HOST = 6;                // Individual server within a domain
-  }
+import "object/credential.proto";
+import "object/domain.proto";
+import "object/org_unit.proto";
+import "object/root.proto";
+import "object/system.proto";
 
-  required Class class = 1;
-  required bytes value = 2;
+message Object {
+  oneof value {
+    ithos.object.Root       root       = 0;
+    ithos.object.Domain     domain     = 1;
+    ithos.object.OrgUnit    org_unit   = 2;
+    ithos.object.System     system     = 3;
+    ithos.object.Credential credential = 4;
+  }
 }

--- a/src/proto/object/credential.proto
+++ b/src/proto/object/credential.proto
@@ -1,3 +1,5 @@
+syntax = "proto3";
+
 package ithos.object;
 
 import "algorithm.proto";
@@ -5,17 +7,17 @@ import "algorithm.proto";
 // Encrypted access credentials
 message Credential {
     enum Type {
-        SIGNATURE_KEY_PAIR = 1; // Public/private keypair
+        SIGNATURE_KEY_PAIR = 0; // Public/private keypair
     }
 
-    required bytes keyid = 1;
-    required Type credential_type = 2;
-    optional string credential_alg = 3;
-    optional EncryptionAlgorithm sealing_alg = 4;
-    optional bytes encrypted_value = 5;
-    optional bytes salt = 6;
-    optional bytes public_key = 7;
-    optional uint64 not_before = 8;
-    optional uint64 not_after = 9;
-    optional string description = 10;
+    bytes keyid = 1;
+    Type credential_type = 2;
+    string credential_alg = 3;
+    EncryptionAlgorithm sealing_alg = 4;
+    bytes encrypted_value = 5;
+    bytes salt = 6;
+    bytes public_key = 7;
+    uint64 not_before = 8;
+    uint64 not_after = 9;
+    string description = 10;
 }

--- a/src/proto/object/domain.proto
+++ b/src/proto/object/domain.proto
@@ -1,6 +1,8 @@
+syntax = "proto3";
+
 package ithos.object;
 
 // Toplevel domain for an organization (i.e. DNS domain)
 message Domain {
-    optional string description = 1;
+    string description = 1;
 }

--- a/src/proto/object/org_unit.proto
+++ b/src/proto/object/org_unit.proto
@@ -1,6 +1,8 @@
+syntax = "proto3";
+
 package ithos.object;
 
 // Unit/department within an organization or other logical grouping
 message OrgUnit {
-    optional string description = 1;
+    string description = 1;
 }

--- a/src/proto/object/root.proto
+++ b/src/proto/object/root.proto
@@ -1,8 +1,10 @@
+syntax = "proto3";
+
 package ithos.object;
 
 import "algorithm.proto";
 
 // Root entry of the directory tree (Root DSE in LDAP parlance)
 message Root {
-    required DigestAlgorithm digest_alg = 1;
+    DigestAlgorithm digest_alg = 1;
 }

--- a/src/proto/object/system.proto
+++ b/src/proto/object/system.proto
@@ -1,6 +1,8 @@
+syntax = "proto3";
+
 package ithos.object;
 
 // System User (i.e. non-human account)
 message System {
-    required string username = 1;
+    string username = 1;
 }

--- a/src/proto/op.proto
+++ b/src/proto/op.proto
@@ -1,3 +1,5 @@
+syntax = "proto3";
+
 package ithos;
 
 import "object.proto";
@@ -5,10 +7,10 @@ import "object.proto";
 // Ops make modifications to the state of the database
 message Op {
   enum Type {
-    ADD = 1;
+    ADD = 0;
   }
 
-  required Type   optype = 1;
-  required string path = 2;
-  optional Object objectclass = 3;
+  Type optype   = 1;
+  string path   = 2;
+  Object object = 3;
 }


### PR DESCRIPTION
Updates all protobufs to use proto3 conventions:

- Add `syntax = "proto3"` to the top of all protos
- Drops required/optional qualifiers
- Use 'oneof' for representing objects
- Make all proto enums begin at 0