### PR TITLE
Remove block ID from block proto/struct

### DIFF
--- a/src/adapter/lmdb.rs
+++ b/src/adapter/lmdb.rs
@@ -117,21 +117,21 @@ impl<'a> Adapter<'a> for LmdbAdapter {
                 return Err(Error::EntryAlreadyExists);
             }
 
-            try!(txn.put(self.state, LOG_ID_KEY, block.id.as_ref()));
+            try!(txn.put(self.state, LOG_ID_KEY, block.id().as_ref()));
         } else if block.parent_id != try!(self.current_block_id(txn)) {
             return Err(Error::Ordering);
         }
 
         // This check should be redundant given the one above, but is here just in case
-        if txn.get(self.blocks, block.id.as_ref()) != Err(Error::NotFound) {
+        if txn.get(self.blocks, block.id().as_ref()) != Err(Error::NotFound) {
             return Err(Error::EntryAlreadyExists);
         }
 
         // Store the new block
-        try!(txn.put(self.blocks, block.id.as_ref(), &try!(block.to_proto())));
+        try!(txn.put(self.blocks, block.id().as_ref(), &try!(block.to_proto())));
 
         // Update the current block ID in the state table
-        try!(txn.put(self.state, LATEST_BLOCK_ID_KEY, block.id.as_ref()));
+        try!(txn.put(self.state, LATEST_BLOCK_ID_KEY, block.id().as_ref()));
 
         Ok(())
     }

--- a/src/proto/block.proto
+++ b/src/proto/block.proto
@@ -9,11 +9,10 @@ import "op.proto";
 // a signature) to carry them out. Some might call it a "blockchain",
 // but in Ithos it is referred to as the log
 message Block {
-  bytes id         = 1;
-  bytes parent     = 2;
-  uint64 timestamp = 3;
-  repeated Op ops  = 4;
-  string comment   = 5;
-  bytes signed_by  = 6;
-  bytes signature  = 7;
+  bytes parent     = 1;
+  uint64 timestamp = 2;
+  repeated Op ops  = 3;
+  string comment   = 4;
+  bytes signed_by  = 5;
+  bytes signature  = 6;
 }


### PR DESCRIPTION
This is part of a gradual transition towards using generated protos. We need to get rid of any discrepancies between how protos are structured and their objecthashes.