### PR TITLE
Split error::Error and error::ErrorKind, adding error messages

### DIFF
--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -70,25 +70,25 @@ impl_algorithm!(EncryptionAlgorithm, EncryptionAlgorithm::Aes256Gcm, "AES256GCM"
 
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub enum CipherSuite {
-    Ed25519Aes256GcmSha256
+    Ed25519Aes256GcmSha256,
 }
 
 impl CipherSuite {
     pub fn signature_alg(&self) -> SignatureAlgorithm {
         match *self {
-            CipherSuite::Ed25519Aes256GcmSha256 => SignatureAlgorithm::Ed25519
+            CipherSuite::Ed25519Aes256GcmSha256 => SignatureAlgorithm::Ed25519,
         }
     }
 
     pub fn encryption_alg(&self) -> EncryptionAlgorithm {
         match *self {
-            CipherSuite::Ed25519Aes256GcmSha256 => EncryptionAlgorithm::Aes256Gcm
+            CipherSuite::Ed25519Aes256GcmSha256 => EncryptionAlgorithm::Aes256Gcm,
         }
     }
 
     pub fn digest_alg(&self) -> DigestAlgorithm {
         match *self {
-            CipherSuite::Ed25519Aes256GcmSha256 => DigestAlgorithm::Sha256
+            CipherSuite::Ed25519Aes256GcmSha256 => DigestAlgorithm::Sha256,
         }
     }
 }

--- a/src/block.rs
+++ b/src/block.rs
@@ -35,7 +35,7 @@ impl Id {
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Id> {
         if bytes.len() != DIGEST_SIZE {
-            return Err(Error::Parse);
+            return Err(Error::parse(None));
         }
 
         let mut id = [0u8; DIGEST_SIZE];

--- a/src/direntry.rs
+++ b/src/direntry.rs
@@ -20,11 +20,11 @@ impl<'a> DirEntry<'a> {
 
     pub fn new(parent_id: Id, bytes: &[u8]) -> Result<DirEntry> {
         if bytes.len() < 8 {
-            return Err(Error::Parse);
+            return Err(Error::parse(None));
         }
 
         let id = try!(Id::from_bytes(&bytes[0..8]));
-        let name = try!(str::from_utf8(&bytes[8..]).map_err(|_| Error::Parse));
+        let name = try!(str::from_utf8(&bytes[8..]).map_err(|_| Error::parse(None)));
 
         Ok(DirEntry {
             id: id,

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -14,7 +14,7 @@ impl Id {
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Id> {
         if bytes.len() != 8 {
-            return Err(Error::Parse);
+            return Err(Error::parse(None));
         }
 
         let mut id = [0u8; 8];
@@ -44,7 +44,7 @@ pub struct Entry<'a> {
 impl<'a> Entry<'a> {
     pub fn from_bytes(id: Id, bytes: &[u8]) -> Result<Entry> {
         if bytes.len() < 4 {
-            return Err(Error::Parse);
+            return Err(Error::parse(None));
         }
 
         Ok(Entry {

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,9 +2,80 @@ use std::error::Error as StdError;
 use std::fmt;
 use std::result::Result as StdResult;
 
+#[derive(Debug, Eq, PartialEq)]
+pub struct Error {
+    pub kind: ErrorKind,
+    pub msg: Option<String>,
+}
+
+impl Error {
+    pub fn new(kind: ErrorKind, msg: Option<&str>) -> Error {
+        Error {
+            kind: kind,
+            msg: msg.map(|s| s.to_string()),
+        }
+    }
+
+    pub fn adapter(msg: Option<&str>) -> Error {
+        Error::new(ErrorKind::Adapter, msg)
+    }
+
+    pub fn system(msg: Option<&str>) -> Error {
+        Error::new(ErrorKind::System, msg)
+    }
+
+    pub fn rng(msg: Option<&str>) -> Error {
+        Error::new(ErrorKind::Rng, msg)
+    }
+
+    pub fn parse(msg: Option<&str>) -> Error {
+        Error::new(ErrorKind::Parse, msg)
+    }
+
+    pub fn serialize(msg: Option<&str>) -> Error {
+        Error::new(ErrorKind::Serialize, msg)
+    }
+
+    pub fn transaction(msg: Option<&str>) -> Error {
+        Error::new(ErrorKind::Transaction, msg)
+    }
+
+    pub fn ordering(msg: Option<&str>) -> Error {
+        Error::new(ErrorKind::Ordering, msg)
+    }
+
+    pub fn path_invalid(msg: Option<&str>) -> Error {
+        Error::new(ErrorKind::PathInvalid, msg)
+    }
+
+    pub fn not_found(msg: Option<&str>) -> Error {
+        Error::new(ErrorKind::NotFound, msg)
+    }
+
+    pub fn entry_already_exists(msg: Option<&str>) -> Error {
+        Error::new(ErrorKind::EntryAlreadyExists, msg)
+    }
+
+    pub fn nesting_invalid(msg: Option<&str>) -> Error {
+        Error::new(ErrorKind::NestingInvalid, msg)
+    }
+
+    pub fn bad_type(msg: Option<&str>) -> Error {
+        Error::new(ErrorKind::BadType, msg)
+    }
+
+    pub fn corrupt_data(msg: Option<&str>) -> Error {
+        Error::new(ErrorKind::CorruptData, msg)
+    }
+
+    pub fn crypto_failure(msg: Option<&str>) -> Error {
+        Error::new(ErrorKind::CryptoFailure, msg)
+    }
+}
+
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
-pub enum Error {
-    Adapter(i32),
+pub enum ErrorKind {
+    Adapter,
     System,
     Rng,
     Parse,
@@ -22,28 +93,32 @@ pub enum Error {
 
 impl StdError for Error {
     fn description(&self) -> &str {
-        match *self {
-            Error::Adapter(_) => "storage adapter returned low-level error",
-            Error::System => "a low-level system error occurred",
-            Error::Rng => "the system random number generator returned an error",
-            Error::Parse => "unable to parse data",
-            Error::Serialize => "unable to serialize data",
-            Error::Transaction => "the current transaction cannot be completed because of an error",
-            Error::Ordering => "data is out-of-sequence with the expected order",
-            Error::PathInvalid => "the given path is syntactically invalid",
-            Error::NotFound => "the requested object was not found",
-            Error::EntryAlreadyExists => "an attempt was made to insert a duplicate entry",
-            Error::NestingInvalid => "attempted to add an object outside of allowed locations",
-            Error::BadType => "expecting an object of a different type",
-            Error::CorruptData => "data was in a corrupt or unexpected state",
-            Error::CryptoFailure => "a cryptographic operation failed",
+        match self.kind {
+            ErrorKind::Adapter => "storage adapter returned low-level error",
+            ErrorKind::System => "a low-level system error occurred",
+            ErrorKind::Rng => "the system random number generator returned an error",
+            ErrorKind::Parse => "unable to parse data",
+            ErrorKind::Serialize => "unable to serialize data",
+            ErrorKind::Transaction => "the transaction failed because of an error",
+            ErrorKind::Ordering => "data is out-of-sequence with the expected order",
+            ErrorKind::PathInvalid => "the given path is syntactically invalid",
+            ErrorKind::NotFound => "the requested object was not found",
+            ErrorKind::EntryAlreadyExists => "an attempt was made to insert a duplicate entry",
+            ErrorKind::NestingInvalid => "attempted to add an object outside of allowed locations",
+            ErrorKind::BadType => "expecting an object of a different type",
+            ErrorKind::CorruptData => "data was in a corrupt or unexpected state",
+            ErrorKind::CryptoFailure => "a cryptographic operation failed",
         }
     }
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{}", self.description())
+        if let Some(ref msg) = self.msg {
+            write!(fmt, "{}: {}", self.description(), msg)
+        } else {
+            write!(fmt, "{}", self.description())
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,10 +39,10 @@ mod signature;
 mod timestamp;
 pub mod witness;
 
-use algorithm::CipherSuite;
 use adapter::lmdb::LmdbAdapter;
+use algorithm::CipherSuite;
 use encryption::AES256GCM_KEY_SIZE;
-use error::Error;
+use error::ErrorKind;
 use path::PathBuf;
 use ring::rand;
 use server::Server;
@@ -112,11 +112,15 @@ fn db_create(database_path: &str, admin_username: &str) {
 
             println!("{password}", password = admin_password);
         }
-        Err(Error::EntryAlreadyExists) => {
-            println!("*** Error: a database already exists at {path}",
-                     path = database_path);
+        Err(err) => {
+            match err.kind {
+                ErrorKind::EntryAlreadyExists => {
+                    println!("*** Error: a database already exists at {path}",
+                             path = database_path)
+                }
+                _ => panic!(err),
+            }
         }
-        Err(err) => panic!(err),
     }
 }
 

--- a/src/object/credential.rs
+++ b/src/object/credential.rs
@@ -32,11 +32,11 @@ impl Type {
     // TODO: actually support more algorithms
     fn from_id_and_alg(credential_id: Option<u32>, credential_alg: Option<String>) -> Result<Type> {
         if credential_id != Some(1) {
-            return Err(Error::Parse);
+            return Err(Error::parse(None));
         }
 
         if credential_alg != Some(String::from("Ed25519")) {
-            return Err(Error::Parse);
+            return Err(Error::parse(None));
         }
 
         Ok(Type::SignatureKeyPair(SignatureAlgorithm::Ed25519))
@@ -93,19 +93,19 @@ impl CredentialEntry {
     pub fn unseal_signature_keypair(&self, symmetric_key_bytes: &[u8]) -> Result<KeyPair> {
         // Ed25519 is the only signature algorithm we presently support
         if self.credential_type != Type::SignatureKeyPair(SignatureAlgorithm::Ed25519) {
-            return Err(Error::BadType);
+            return Err(Error::bad_type(None));
         }
 
         let encrypted_value = match self.encrypted_value {
             Some(ref value) => value,
-            None => return Err(Error::CorruptData),
+            None => return Err(Error::corrupt_data(None)),
         };
 
-        let sealing_alg = try!(self.sealing_alg.ok_or(Error::CorruptData));
+        let sealing_alg = try!(self.sealing_alg.ok_or(Error::corrupt_data(None)));
 
         let public_key = match self.public_key {
             Some(ref key) => key,
-            None => return Err(Error::CorruptData),
+            None => return Err(Error::corrupt_data(None)),
         };
 
         KeyPair::unseal(SignatureAlgorithm::Ed25519,

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -37,7 +37,7 @@ pub enum Class {
 impl Class {
     pub fn from_bytes(bytes: &[u8]) -> Result<Class> {
         if bytes.len() != 4 {
-            return Err(Error::Parse);
+            return Err(Error::parse(None));
         }
 
         let mut id_bytes = [0u8; 4];
@@ -51,7 +51,7 @@ impl Class {
             2 => Class::OrgUnit,
             3 => Class::System,
             4 => Class::Credential,
-            _ => return Err(Error::Parse),
+            _ => return Err(Error::parse(None)),
         };
 
         Ok(result)

--- a/src/op.rs
+++ b/src/op.rs
@@ -98,21 +98,21 @@ impl Op {
                 let parent_entry = try!(state.get_entry(adapter, txn, path));
 
                 if !parent_entry.class.allows_child(&self.object) {
-                    return Err(Error::NestingInvalid);
+                    return Err(Error::nesting_invalid(None));
                 }
 
                 (parent_entry.id, state.get_next_entry_id())
             }
             None => {
                 if self.object.class() != Class::Root {
-                    return Err(Error::NestingInvalid);
+                    return Err(Error::nesting_invalid(None));
                 }
 
                 (entry::Id::root(), entry::Id::root())
             }
         };
 
-        let name = try!(self.path.as_path().entry_name().ok_or(Error::PathInvalid));
+        let name = try!(self.path.as_path().entry_name().ok_or(Error::path_invalid(None)));
         let metadata = Metadata::new(*block_id, timestamp);
         let proto = try!(self.object.to_proto());
 
@@ -247,7 +247,7 @@ pub mod tests {
                                   &example_block_id,
                                   example_timestamp());
 
-            assert_eq!(result, Err(Error::NestingInvalid));
+            assert_eq!(result, Err(Error::nesting_invalid(None)));
         }
 
         // Test nesting constraints on a non-root entry
@@ -280,7 +280,7 @@ pub mod tests {
                                     &example_block_id,
                                     example_timestamp());
 
-            assert_eq!(result2, Err(Error::NestingInvalid));
+            assert_eq!(result2, Err(Error::nesting_invalid(None)));
         }
     }
 }

--- a/src/password.rs
+++ b/src/password.rs
@@ -38,13 +38,13 @@ pub fn generate(rng: &SecureRandom) -> String {
 
 pub fn random_salt(rng: &SecureRandom) -> Result<[u8; RANDOM_SALT_SIZE]> {
     let mut salt = [0u8; RANDOM_SALT_SIZE];
-    try!(rng.fill(&mut salt).map_err(|_| Error::Rng));
+    try!(rng.fill(&mut salt).map_err(|_| Error::rng(None)));
     Ok(salt)
 }
 
 // Prompt for a password from standard input
 pub fn prompt(message: &str) -> Result<String> {
-    rpassword::prompt_password_stdout(message).map_err(|_| Error::System)
+    rpassword::prompt_password_stdout(message).map_err(|_| Error::system(None))
 }
 
 // Use a weak set of parameters when running tests to reduce test times

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -6,7 +6,7 @@ pub trait ToProto
     where Self: Sized + Serialize
 {
     fn to_proto(&self) -> Result<Vec<u8>> {
-        buffoon::serialize(&self).map_err(|_| Error::Serialize)
+        buffoon::serialize(&self).map_err(|_| Error::serialize(None))
     }
 }
 
@@ -14,6 +14,6 @@ pub trait FromProto
     where Self: Sized + Deserialize
 {
     fn from_proto(bytes: &[u8]) -> Result<Self> {
-        buffoon::deserialize(bytes).map_err(|_| Error::Parse)
+        buffoon::deserialize(bytes).map_err(|_| Error::parse(None))
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -113,15 +113,15 @@ impl<A> Server<A>
     pub fn find_credential(&self, path: &Path) -> Result<CredentialEntry> {
         match try!(Object::find(&self.adapter, path)) {
             Object::Credential(credential_entry) => Ok(credential_entry),
-            _ => Err(Error::BadType),
+            _ => Err(Error::bad_type(None)),
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use algorithm::CipherSuite;
     use adapter::lmdb::LmdbAdapter;
+    use algorithm::CipherSuite;
     use encryption::AES256GCM_KEY_SIZE;
     use password::{self, PasswordAlgorithm};
     use path::PathBuf;
@@ -137,7 +137,11 @@ mod tests {
     fn create_database() -> Server<LmdbAdapter> {
         let rng = rand::SystemRandom::new();
         let dir = TempDir::new("ithos-test").unwrap();
-        Server::<LmdbAdapter>::create_database(dir.path(), &rng, CipherSuite::Ed25519Aes256GcmSha256, ADMIN_USERNAME, ADMIN_PASSWORD)
+        Server::<LmdbAdapter>::create_database(dir.path(),
+                                               &rng,
+                                               CipherSuite::Ed25519Aes256GcmSha256,
+                                               ADMIN_USERNAME,
+                                               ADMIN_PASSWORD)
             .unwrap();
         Server::<LmdbAdapter>::open_database(dir.path()).unwrap()
     }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -75,7 +75,7 @@ impl<'a> KeyPair {
 
         let (keypair, serializable_keypair) =
             try!(signature_impl::Ed25519KeyPair::generate_serializable(rng)
-                .map_err(|_| Error::CryptoFailure));
+                .map_err(|_| Error::crypto_failure(None)));
 
         let ciphertext = try!(encryption::seal(encryption_alg,
                                                sealing_key,
@@ -102,7 +102,7 @@ impl<'a> KeyPair {
         let private_key = try!(encryption::unseal(encryption_alg, sealing_key, sealed_keypair));
 
         let keypair = try!(signature_impl::Ed25519KeyPair::from_bytes(&private_key, &public_key)
-            .map_err(|_| Error::CryptoFailure));
+            .map_err(|_| Error::crypto_failure(None)));
 
         Ok(KeyPair {
             algorithm: SignatureAlgorithm::Ed25519,


### PR DESCRIPTION
Errors can now contain an optional message generated at runtime. This should hopefully make it easier to provide more meaningful error messages.