### PR TITLE
Factor block and entry IDs into id::{BlockId, EntryId}

### DIFF
--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -1,9 +1,10 @@
 pub mod lmdb;
 
-use block::{self, Block};
+use block::Block;
 use direntry::DirEntry;
-use entry::{self, SerializedEntry};
+use entry::SerializedEntry;
 use error::Result;
+use id::{BlockId, EntryId};
 use metadata::Metadata;
 use path;
 use std::marker::Sized;
@@ -29,22 +30,22 @@ pub trait Adapter<'a> {
     fn ro_transaction(&'a self) -> Result<Self::R>;
     fn rw_transaction(&'a self) -> Result<Self::W>;
 
-    fn next_free_entry_id(&self, txn: &Self::W) -> Result<entry::Id>;
+    fn next_free_entry_id(&self, txn: &Self::W) -> Result<EntryId>;
 
     fn add_block<'t>(&'t self, txn: &'t mut Self::W, block: &Block) -> Result<()>;
-    fn current_block_id<'t, T>(&'t self, txn: &'t T) -> Result<block::Id>
+    fn current_block_id<'t, T>(&'t self, txn: &'t T) -> Result<BlockId>
         where T: Transaction<D = Self::D>;
     fn add_entry<'t>(&'t self,
                      txn: &'t mut Self::W,
                      entry: &SerializedEntry,
                      name: &'t str,
-                     parent_id: entry::Id,
+                     parent_id: EntryId,
                      metadata: &Metadata)
                      -> Result<DirEntry>;
     fn find_direntry<'t, T>(&'t self, txn: &'t T, path: &path::Path) -> Result<DirEntry>
         where T: Transaction<D = Self::D>;
-    fn find_metadata<'t, T>(&'t self, txn: &'t T, id: &entry::Id) -> Result<Metadata>
+    fn find_metadata<'t, T>(&'t self, txn: &'t T, id: &EntryId) -> Result<Metadata>
         where T: Transaction<D = Self::D>;
-    fn find_entry<'t, T>(&'t self, txn: &'t T, id: &entry::Id) -> Result<SerializedEntry>
+    fn find_entry<'t, T>(&'t self, txn: &'t T, id: &EntryId) -> Result<SerializedEntry>
         where T: Transaction<D = Self::D>;
 }

--- a/src/block.rs
+++ b/src/block.rs
@@ -27,50 +27,6 @@ use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
 use rustc_serialize::base64::{self, ToBase64};
 use witness::Witness;
 
-// TODO: HAND EDITS START HERE! REFACTOR THIS CODE!!!
-const DIGEST_SIZE: usize = 32;
-
-// Block IDs are presently SHA-256 only
-#[derive(Debug, Eq, PartialEq, Copy, Clone)]
-pub struct Id([u8; DIGEST_SIZE]);
-
-impl Id {
-    // Parent ID of the initial block (256-bits of zero)
-    pub fn zero() -> Id {
-        Id([0u8; DIGEST_SIZE])
-    }
-
-    pub fn from_bytes(bytes: &[u8]) -> Result<Id> {
-        if bytes.len() != DIGEST_SIZE {
-            return Err(Error::parse(None));
-        }
-
-        let mut id = [0u8; DIGEST_SIZE];
-        id.copy_from_slice(&bytes[0..DIGEST_SIZE]);
-
-        Ok(Id(id))
-    }
-
-    pub fn of(block: &Block) -> Id {
-        Id::from_bytes(objecthash::digest(block).as_ref()).unwrap()
-    }
-}
-
-impl AsRef<[u8]> for Id {
-    #[inline]
-    fn as_ref(&self) -> &[u8] {
-        &self.0
-    }
-}
-
-impl ObjectHash for Id {
-    fn objecthash<H: ObjectHasher>(&self, hasher: &mut H) {
-        self.0.objecthash(hasher);
-    }
-}
-
-// TODO: HAND EDITS END HERE!!!
-
 #[derive(Clone,Default)]
 pub struct Body {
     // message fields

--- a/src/direntry.rs
+++ b/src/direntry.rs
@@ -1,29 +1,29 @@
-use entry::Id;
 use error::{Error, Result};
+use id::EntryId;
 use std::str;
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct DirEntry<'a> {
-    pub id: Id,
-    pub parent_id: Id,
+    pub id: EntryId,
+    pub parent_id: EntryId,
     pub name: &'a str,
 }
 
 impl<'a> DirEntry<'a> {
     pub fn root() -> DirEntry<'a> {
         DirEntry {
-            id: Id::root(),
-            parent_id: Id::root(),
+            id: EntryId::root(),
+            parent_id: EntryId::root(),
             name: "/",
         }
     }
 
-    pub fn new(parent_id: Id, bytes: &[u8]) -> Result<DirEntry> {
+    pub fn new(parent_id: EntryId, bytes: &[u8]) -> Result<DirEntry> {
         if bytes.len() < 8 {
             return Err(Error::parse(None));
         }
 
-        let id = try!(Id::from_bytes(&bytes[0..8]));
+        let id = try!(EntryId::from_bytes(&bytes[0..8]));
         let name = try!(str::from_utf8(&bytes[8..]).map_err(|_| Error::parse(None)));
 
         Ok(DirEntry {

--- a/src/id.rs
+++ b/src/id.rs
@@ -1,0 +1,78 @@
+use block::Block;
+use error::{Error, Result};
+use objecthash::{self, ObjectHash, ObjectHasher};
+use std::mem;
+
+const DIGEST_SIZE: usize = 32;
+
+// Block IDs are presently SHA-256 only
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+pub struct BlockId([u8; DIGEST_SIZE]);
+
+impl BlockId {
+    // Parent ID of the initial block (256-bits of zero)
+    pub fn zero() -> BlockId {
+        BlockId([0u8; DIGEST_SIZE])
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<BlockId> {
+        if bytes.len() != DIGEST_SIZE {
+            return Err(Error::parse(None));
+        }
+
+        let mut id = [0u8; DIGEST_SIZE];
+        id.copy_from_slice(&bytes[0..DIGEST_SIZE]);
+
+        Ok(BlockId(id))
+    }
+
+    pub fn of(block: &Block) -> BlockId {
+        BlockId::from_bytes(objecthash::digest(block).as_ref()).unwrap()
+    }
+}
+
+impl AsRef<[u8]> for BlockId {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl ObjectHash for BlockId {
+    fn objecthash<H: ObjectHasher>(&self, hasher: &mut H) {
+        self.0.objecthash(hasher);
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+pub struct EntryId(u64);
+
+// EntryIds are 64-bit integers in host-native byte order
+// LMDB has special optimizations for host-native integers as keys
+impl EntryId {
+    pub fn root() -> EntryId {
+        EntryId(0)
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<EntryId> {
+        if bytes.len() != 8 {
+            return Err(Error::parse(None));
+        }
+
+        let mut id = [0u8; 8];
+        id.copy_from_slice(&bytes[0..8]);
+
+        Ok(EntryId(unsafe { mem::transmute(id) }))
+    }
+
+    pub fn next(self) -> EntryId {
+        EntryId(self.0 + 1)
+    }
+}
+
+impl AsRef<[u8; 8]> for EntryId {
+    #[inline]
+    fn as_ref(&self) -> &[u8; 8] {
+        unsafe { mem::transmute(&self.0) }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ mod crypto;
 mod direntry;
 mod entry;
 mod error;
+mod id;
 mod metadata;
 mod object;
 mod op;

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,6 +1,7 @@
 use algorithm::{CipherSuite, EncryptionAlgorithm, DigestAlgorithm};
 use block::{self, Block, Body};
 use crypto::signing::KeyPair;
+use id::BlockId;
 use object::Object;
 use object::credential::{self, Credential};
 use object::domain::Domain;
@@ -135,7 +136,7 @@ pub fn create_log(ciphersuite: CipherSuite,
     ops.push(admin_signing_credential_op);
 
     let mut body = Body::new();
-    body.set_parent_id(Vec::from(block::Id::zero().as_ref()));
+    body.set_parent_id(Vec::from(BlockId::zero().as_ref()));
     body.set_timestamp(timestamp.to_int());
     body.set_ops(RepeatedField::from_vec(ops));
     body.set_comment(comment.to_owned());


### PR DESCRIPTION
Moves all (similar-looking) ID-related types into a single module