### PR TITLE
Trying to be the first thing to cite RFC 8032

### DIFF
--- a/src/crypto/signing.rs
+++ b/src/crypto/signing.rs
@@ -1,3 +1,11 @@
+//! crypto/signing.rs: Digital signature functionality
+//!
+//! This module contains types for producing digital signatures. Digital signatures are primarily
+//! used to authenticate and authorize changes to the directory tree.
+//!
+//! The Ed25519 digital signature algorithm (RFC 8032) is presently the only one supported
+//!
+
 use algorithm::{EncryptionAlgorithm, SignatureAlgorithm};
 use block::{Block, Body};
 use crypto;


### PR DESCRIPTION
RFC 8032 (EdDSA) has been approved by both authors:

https://www.rfc-editor.org/auth48/rfc8032

It should be published very soon (at which point the above URL will 404):

https://tools.ietf.org/html/rfc8032