### PR TITLE
Deny unsafe code (fixing some instances of it)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,6 +2,7 @@
 name = "ithos"
 version = "0.0.0"
 dependencies = [
+ "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.22.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -38,6 +39,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "bitflags"
 version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byteorder"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -278,6 +284,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d912da0db7fa85514874458ca3651fe2cddace8d0b0505571dbdcd41ab490159"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1370e9fc2a6ae53aea8b7a5110edbd08836ed87c88736dfabccade1c2b44bff4"
+"checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
 "checksum clap 2.22.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3cae8c5a1108961e9bafb1096b8cbb6a31c17ab1a276ce9b52334be99962f653"
 "checksum deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1614659040e711785ed8ea24219140654da1729f3ec8a47a9719d041112fe7bf"
 "checksum gcc 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)" = "40899336fb50db0c78710f53e87afc54d8c7266fb76262fecc78ca1a7f09deae"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ version     = "0.0.0"
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 
 [dependencies]
+byteorder       = "^0.5"
 clap            = "^2.22"
 protobuf        = "^1.0"
 rustc-serialize = "^0.3"

--- a/src/adapter/lmdb.rs
+++ b/src/adapter/lmdb.rs
@@ -20,10 +20,10 @@ use id::{BlockId, EntryId};
 use metadata::Metadata;
 use path::Path;
 use protobuf::{self, Message};
-use std::{self, str};
 use std::error::Error as StdError;
 use std::io::Write;
 use std::path::Path as StdPath;
+use std::str;
 
 const MAX_DBS: u32 = 8;
 const DB_PERMS: lmdb_sys::mode_t = 0o600;

--- a/src/id.rs
+++ b/src/id.rs
@@ -4,6 +4,7 @@
 //!
 
 use block::Block;
+use byteorder::{ByteOrder, NativeEndian};
 use error::{Error, Result};
 use objecthash::{self, ObjectHash, ObjectHasher};
 use std::mem;
@@ -68,10 +69,7 @@ impl EntryId {
             return Err(Error::parse(None));
         }
 
-        let mut id = [0u8; 8];
-        id.copy_from_slice(&bytes[0..8]);
-
-        Ok(EntryId(unsafe { mem::transmute(id) }))
+        Ok(EntryId(NativeEndian::read_u64(bytes)))
     }
 
     /// Obtain the next sequential EntryID after this one
@@ -81,7 +79,9 @@ impl EntryId {
 }
 
 impl AsRef<[u8; 8]> for EntryId {
+    // TODO: get rid of transmute
     #[inline]
+    #[allow(unsafe_code)]
     fn as_ref(&self) -> &[u8; 8] {
         unsafe { mem::transmute(&self.0) }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,11 +3,12 @@
 #![crate_name = "ithos"]
 #![crate_type = "bin"]
 
-#![deny(missing_docs)]
+#![deny(missing_docs, unsafe_code)]
 
 extern crate clap;
 use clap::{App, Arg, SubCommand};
 
+extern crate byteorder;
 #[macro_use]
 extern crate objecthash;
 extern crate protobuf;
@@ -130,12 +131,11 @@ fn domain_add(database_path: &str, admin_username: &str, domain_name: &str) {
              path = database_path,
              domain = domain_name);
 
-    let server = Server::open_database(StdPath::new(database_path))
-        .unwrap_or_else(|err| {
-            panic!("*** Error: couldn't open database at {path}: {err}",
-                   path = database_path,
-                   err = err);
-        });
+    let server = Server::open_database(StdPath::new(database_path)).unwrap_or_else(|err| {
+        panic!("*** Error: couldn't open database at {path}: {err}",
+               path = database_path,
+               err = err);
+    });
 
     let mut keypair_path = PathBuf::new();
     keypair_path.push("global");

--- a/src/path.rs
+++ b/src/path.rs
@@ -82,6 +82,8 @@ impl Path {
     /// Create a new `Path` from the given string
     pub fn new<S: AsRef<str> + ?Sized>(s: &S) -> Option<&Path> {
         if s.as_ref().starts_with(SEPARATOR) {
+            // TODO: get rid of transmute
+            #[allow(unsafe_code)]
             Some(unsafe { mem::transmute(s.as_ref()) })
         } else {
             None

--- a/src/server.rs
+++ b/src/server.rs
@@ -25,8 +25,8 @@ use path::{Path, PathBuf};
 use protobuf::RepeatedField;
 use ring::rand::SecureRandom;
 use setup;
-use std::{self, str};
 use std::path::Path as StdPath;
+use std::str;
 use timestamp::Timestamp;
 use transform::Transform;
 


### PR DESCRIPTION
Adds #[deny(unsafe_code)] at the toplevel, and replaces some uses of transmute
with the byteorder gem.

There are still a few usages of transmute that are difficult to replace. They've
been marked with TODOs.